### PR TITLE
Bump to container image 0.23.0

### DIFF
--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -3,7 +3,7 @@
 image:
   registry: docker.io
   repository: falcosecurity/falco
-  tag: 0.21.0
+  tag: 0.23.0
   pullPolicy: IfNotPresent
 
 docker:


### PR DESCRIPTION
Version 0.21.0 was failing on GKE 

```
[nova@nova ~]$ k logs falco-xgg9l -f
* Setting up /usr/src links from host
* Mounting debugfs
Found kernel config at /proc/config.gz
* COS detected (build 12371.208.0), using cos kernel headers...
* Downloading https://storage.googleapis.com/cos-tools/12371.208.0/kernel-headers.tgz
* Extracting kernel sources
* Configuring kernel
* Trying to compile BPF probe falco-probe-bpf (falco-probe-bpf-latest-x86_64-4.19.109+-c49f5fbc35a5b76e9ca8d47acc2b1913.o)
make: *** /usr/src/falco-latest/bpf: No such file or directory.  Stop.
mv: cannot stat '/usr/src/falco-latest/bpf/probe.o': No such file or directory
* Trying to download precompiled BPF probe from https://s3.amazonaws.com/download.draios.com/stable/sysdig-probe-binaries/falco-probe-bpf-latest-x86_64-4.19.109%2B-c49f5fbc35a5b76e9ca8d47acc2b1913.o
curl: (22) The requested URL returned error: 404 Not Found
* Failure to find a BPF probe
Fri May 22 11:22:15 2020: Falco initialized with configuration file /etc/falco/falco.yaml
Fri May 22 11:22:15 2020: Loading rules from file /etc/falco/falco_rules.yaml:
Fri May 22 11:22:16 2020: Loading rules from file /etc/falco/falco_rules.local.yaml:
Fri May 22 11:22:16 2020: Unable to load the driver. Exiting.
Fri May 22 11:22:16 2020: Runtime error: can't open BPF probe '/root/.falco/falco-probe-bpf.o': Errno 2. Exiting.
```

Now that we have moved away from the old BPF loading logic - this bump gets falco up and running in GKE