### PR TITLE
Set up releases and helm hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,27 @@
+# Falco Helm Charts
 
-> Acts as a template for new repositories
+This repo contains [helm](https://helm.sh/) charts for installing falco and related utilities.
 
-## Workflow
+## Usage
 
-1. Above the file list, click **Use this template** button.
-2. Type a name for your repository, and an optional description.
-3. Click **Create repository from template**.
-4. Edit the README.md file.
-5. Edit the OWNERS file adding/removing people for the specific project.
-6. Open an issue into [test-infra](https://github.com/falcosecurity/test-infra) to notify maintainers to enable Prow on the specific project
-7. DO NOT edit the LICENSE file which we'll be already in place
+From git:
+
+```bash
+git clone https://github.com/falcosecurity/charts
+cd charts/falco
+# optional
+vim values.yaml
+helm install falco .
+```
+
+From helm repository:
+
+```
+helm repo add https://falcosecurity.github.io/charts`
+helm search repo | grep falco
+helm install falco falcosecurity/falco
+```
+
+# Releases
+
+The [helm hub]() repository for falco is stored in the `gh-pages` branch of this repository. The repo and releases (`.tgz` files) are managed by the `release.sh` script in the main repository.

--- a/release.sh
+++ b/release.sh
@@ -16,7 +16,7 @@ pushd ../gh-pages
 git checkout gh-pages
 
 #TODO rename to falcosecurity before merge
-helm repo index . --url https://nibalizer.github.com/charts
+helm repo index . --url https://falcosecurity.github.com/charts
 
 # Create json representation (because my browser wont render yaml)
 cat index.yaml | python -c 'import sys, yaml, json; y=yaml.load(sys.stdin.read()); print json.dumps(y)' | jq '.' > index.json

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ ! -d ../gh-pages/.git ]; then
+    echo "Need to set up 'gh-pages' clone in directory above for this script to work"
+    echo "Run:"
+    echo "cd .."
+    echo "git clone git@github.com/falcosecurity/charts gh-pages"
+    echo "cd gh-pages"
+    echo "git checkout gh-pages"
+    exit 1
+fi
+
+helm package falco
+mv *.tgz ../gh-pages/
+pushd ../gh-pages
+git checkout gh-pages
+
+#TODO rename to falcosecurity before merge
+helm repo index . --url https://nibalizer.github.com/charts
+
+# Create json representation (because my browser wont render yaml)
+cat index.yaml | python -c 'import sys, yaml, json; y=yaml.load(sys.stdin.read()); print json.dumps(y)' | jq '.' > index.json
+
+git add .
+
+git commit -m "Helm chart/repo release $(date +%F)"
+
+git push origin gh-pages


### PR DESCRIPTION
This pull request sets us up for creating our own helm hub and release pipeline. It also needs a few things:

1) Use this branch as a template for creating our own `gh-pages` branch: <https://github.com/nibalizer/charts/tree/import_gh_pages>
2) Enable Github Pages in the Settings
3) Until automation is set up, manual releases require a specific directory structure (outlined in `release.sh`)


After those things are in place we'll have a repo that [looks like this](https://nibalizer.github.io/charts/). That can be used today with:

```bash
helm repo add nibz https://nibalizer.github.io/charts/
helm search repo | grep falco
helm install falco nibz/falco
```

In the future `falcosecruity` will replace the other words.