### PR TITLE
fix(falco): add missing privileges for the apps Kubernetes API group

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+### Minor Changes
+
+* Add missing privileges for the apps Kubernetes API group
+
 ## v1.1.8
 
 ### Minor Changes

--- a/falco/templates/clusterrole.yaml
+++ b/falco/templates/clusterrole.yaml
@@ -27,6 +27,17 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
   - nonResourceURLs:
       - /healthz
       - /healthz/*


### PR DESCRIPTION
Porting [this fix](https://github.com/falcosecurity/falco/pull/1136) to the chart.

/kind bug
/cc @fntlnz 