### PR TITLE
release(falco): 1.1.20

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,10 +3,14 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.1.10
+
 ### Minor Changes
 
 * Switch to `falcosecurity/event-generator`
 * Allow configuration using values for `fakeEventGenerator.args` setting
+* Update ruleset
+* New releasing mechanism
 
 ## v1.1.9
 

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 1.1.9
+version: 1.1.20
 appVersion: 0.23.0
 description: Falco
 keywords:


### PR DESCRIPTION
This release introduces small changes (see the [changelog](https://github.com/falcosecurity/charts/compare/release/falco-1.1.10?expand=1#diff-fe5da4546bd141b139a070e83b4930b3R8)) and is mainly intended to test the new releasing automation.