### PR TITLE
Add SCC to support Openshift

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.2.1
+
+### Minor Changes
+
+* Add SecurityContextConstraint to allow deploying in Openshift
+
 ## v1.2.0
 
 ### Minor Changes

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 1.2.0
+version: 1.2.1
 appVersion: 0.24.0
 description: Falco
 keywords:

--- a/falco/README.md
+++ b/falco/README.md
@@ -138,6 +138,7 @@ The following table lists the configurable parameters of the Falco chart and the
 | `nodeSelector`                                  | The node selection constraint                                                                                      | `{}`                                                                                                                                      |
 | `affinity`                                      | The affinity constraint                                                                                            | `{}`                                                                                                                                      |
 | `tolerations`                                   | The tolerations for scheduling                                                                                     | `node-role.kubernetes.io/master:NoSchedule`                                                                                               |
+| `scc.create`                                    | Create OpenShift's Security Context Constraint                                                                     | `true` 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/falco/templates/securitycontextconstraints.yaml
+++ b/falco/templates/securitycontextconstraints.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.scc.create (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: |
+      This provides the minimum requirements Falco to run in Openshift.
+  name: {{ template "falco.fullname" . }}
+  labels:
+    app: {{ template "falco.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: []
+allowedUnsafeSysctls: []
+defaultAddCapabilities: []
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: 0
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ template "falco.serviceAccountName" .}}
+volumes:
+- hostPath
+- emptyDir
+- secret
+- configMap
+{{- end }}

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -337,3 +337,7 @@ integrations:
 tolerations:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
+
+scc:
+  # true here enabled creation of Security Context Constraints in Openshift
+  create: true


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

The daemonset fails to create the pods in Openshift environment due to the request of elevated privileges, like HostPath mounts, privileged: true, etc.

This PR adds a SCC resource which is only created in Openshift (detected via API capabilities in the chart), and that can be disabled with scc.create: false in the values.yaml

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
