### PR TITLE
fix dir mounting collision when both gRPC and nats are enabled

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.2.2
+
+### Minor Changes
+
+* Fix dir mounting collision when both gRPC and nats are enabled
+
 ## v1.2.1
 
 ### Minor Changes

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 1.2.1
+version: 1.2.2
 appVersion: 0.24.0
 description: Falco
 keywords:

--- a/falco/templates/_helpers.tpl
+++ b/falco/templates/_helpers.tpl
@@ -73,3 +73,21 @@ Extract the unixSocket's directory path
 {{- .Values.falco.grpc.unixSocketPath | trimPrefix "unix://" | dir -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Extract the unixSocket's directory path and add /host prefix
+*/}}
+{{- define "falco.unixSocketDirWithPrefix" -}}
+{{- if .Values.falco.grpc.unixSocketPath -}}
+/host{{- .Values.falco.grpc.unixSocketPath | trimPrefix "unix://" | dir -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Add /host prefix to the unixSocketPath
+*/}}
+{{- define "falco.unixSocketPathWithPrefix" -}}
+{{- if .Values.falco.grpc.unixSocketPath -}}
+unix:///host{{- .Values.falco.grpc.unixSocketPath | trimPrefix "unix://" -}}
+{{- end -}}
+{{- end -}}

--- a/falco/templates/configmap.yaml
+++ b/falco/templates/configmap.yaml
@@ -187,7 +187,7 @@ data:
       enabled: {{ .Values.falco.grpc.enabled }}
       threadiness: {{ .Values.falco.grpc.threadiness }}
       {{- if .Values.falco.grpc.unixSocketPath }}
-      bind_address: "{{ .Values.falco.grpc.unixSocketPath }}"
+      bind_address: "{{ include "falco.unixSocketPathWithPrefix" . }}"
       {{ else }}
       bind_address: "0.0.0.0:{{ .Values.falco.grpc.listenPort }}"
       private_key: {{ .Values.falco.grpc.privateKey }}

--- a/falco/templates/daemonset.yaml
+++ b/falco/templates/daemonset.yaml
@@ -131,7 +131,7 @@ spec:
             {{- end }}
             {{- if .Values.falco.grpc.enabled }}
             {{- if .Values.falco.grpc.unixSocketPath }}
-            - mountPath: {{ include "falco.unixSocketDir" . }}
+            - mountPath: {{ include "falco.unixSocketDirWithPrefix" . }}
               name: grpc-socket-dir
             {{- else }}
             - mountPath: /etc/falco/certs


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falco-chart



<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes the duplicate `/var/run/falco` mounting problem (when both gRPC and nats are enabled) by prefixing mounting point inside the container with `/host` for the gRPC Unix socket path.
Note that at the host level the mounting point is still equal to one specified by the config (ie. without the `/host` prefix)


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #54 

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
