### PR TITLE
Add 'docker.io/falcosecurity/falco' image to 'falco_privileged_images' macro

### DIFF
--- a/falco/rules/falco_rules.yaml
+++ b/falco/rules/falco_rules.yaml
@@ -1838,7 +1838,8 @@
     docker.io/sysdig/agent, docker.io/sysdig/falco, docker.io/sysdig/sysdig,
     gcr.io/google_containers/kube-proxy, docker.io/calico/node, quay.io/calico/node,
     docker.io/rook/toolbox, docker.io/cloudnativelabs/kube-router, docker.io/mesosphere/mesos-slave,
-    docker.io/docker/ucp-agent, sematext_images, k8s.gcr.io/kube-proxy
+    docker.io/docker/ucp-agent, sematext_images, k8s.gcr.io/kube-proxy,
+    docker.io/falcosecurity/falco
     ]
 
 - macro: falco_privileged_containers


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

Prevent warning message from falco when booting falco itself. Below is a sample message :
```
Warning Pod started with privileged container (user=system:serviceaccount:kube-system:daemon-set-controller pod=falco-42brw ns=monitoring images=docker.io/falcosecurity/falco:0.24.0)
```
