### PR TITLE
[falco-exporter] Adding Service Monitor deployment

### DIFF
--- a/falco-exporter/CHANGELOG.md
+++ b/falco-exporter/CHANGELOG.md
@@ -7,16 +7,16 @@ numbering uses [semantic versioning](http://semver.org).
 
 ### Minor Changes
 
-- Added the support to deploy a Prometheus Service Monitor. Is disables by default.
+* Added the support to deploy a Prometheus Service Monitor. Is disables by default.
 
 ## v0.3.0
 
 ### Major Changes
 
-- Chart moved to [falcosecurity/charts](https://github.com/falcosecurity/charts) repository
-- gRPC over unix socket support (by default)
-- Updated falco-exporter version to `0.3.0`
+* Chart moved to [falcosecurity/charts](https://github.com/falcosecurity/charts) repository
+* gRPC over unix socket support (by default)
+* Updated falco-exporter version to `0.3.0`
 
 ### Minor Changes
 
-- README.md and CHANGELOG.md added
+* README.md and CHANGELOG.md added

--- a/falco-exporter/CHANGELOG.md
+++ b/falco-exporter/CHANGELOG.md
@@ -3,14 +3,20 @@
 This file documents all notable changes to `falco-exporter` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.3.1
+
+### Minor Changes
+
+- Added the support to deploy a Prometheus Service Monitor. Is disables by default.
+
 ## v0.3.0
 
 ### Major Changes
 
-* Chart moved to [falcosecurity/charts](https://github.com/falcosecurity/charts) repository
-* gRPC over unix socket support (by default)
-* Updated falco-exporter version to `0.3.0`
+- Chart moved to [falcosecurity/charts](https://github.com/falcosecurity/charts) repository
+- gRPC over unix socket support (by default)
+- Updated falco-exporter version to `0.3.0`
 
 ### Minor Changes
 
-* README.md and CHANGELOG.md added
+- README.md and CHANGELOG.md added

--- a/falco-exporter/Chart.yaml
+++ b/falco-exporter/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/falco-exporter/README.md
+++ b/falco-exporter/README.md
@@ -49,10 +49,14 @@ The following table lists the main configurable parameters of the chart and thei
 | Parameter                        | Description                                                         | Default                                        |
 | ---                              | ---                                                                 | ---                                            |
 | `image.repository`               | The image repository to pull from                                   | `falcosecurity/falco-exporter`                 |
-| `image.tag`                      | The image tag to pull                                               | `0.3.0`                                       |
+| `image.tag`                      | The image tag to pull                                               | `0.3.0`                                        |
 | `image.pullPolicy`               | The image pull policy                                               | `IfNotPresent`                                 |
 | `falco.grpcUnixSocketPath`       | Unix socket path for connecting to a Falco gRPC server              | `unix:///var/run/falco/falco.sock`             |
 | `falco.grpcTimeout`              | The image tag to pull                                               | `2m`                                           |
+| `serviceMonitor.enabled`         | Enabled deployment of a Prometheus operator Service Monitor         | `false`                                        |
+| `serviceMonitor.additionalLabels`| Add additional Labels to the Service Monitor                        | `{}`                                           |
+| `serviceMonitor.interval`        | Specify a user defined interval for the Service Monitor             | `""`                                           |
+| `serviceMonitor.scrapeTimeout`   | Specify a user defined scrape timeout for the Service Monitor       | `""`                                           |
 
 Please, refer to [values.yaml](./values.yaml) for the full list of configurable parameters.
 

--- a/falco-exporter/templates/servicemonitor.yaml
+++ b/falco-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,24 @@
+{{ if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "falco-exporter.fullname" . }}
+  labels:
+    {{- include "falco-exporter.labels" . | nindent 4 }}
+      {{- if .Values.serviceMonitor.additionalLabels }}
+    {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
+      {{- end }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+  - port: metrics
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "falco-exporter.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/falco-exporter/values.yaml
+++ b/falco-exporter/values.yaml
@@ -66,3 +66,13 @@ tolerations:
     key: node-role.kubernetes.io/master
 
 affinity: {}
+
+serviceMonitor:
+  # Enable the deployment of a Service Monitor for the Prometheus Operator.
+  enabled: false
+  # Specify Additional labels to be added on the Service Monitor.
+  additionalLabels: {}
+  # Specify a user defined interval. When not specified Prometheus default interval is used.
+  interval: ""
+  # Specify a user defined scrape timeout. When not specified Prometheus default scrape timeout is used.
+  scrapeTimeout: ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falco-exporter-chart


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds the capability to deploy a Prometheus Operator Service Monitor together with the Exporter.

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x ] Chart Version bumped
- [x ] Variables are documented in the README.md
- [x ] CHANGELOG.md updated
