### PR TITLE
Add imagePullSecretes to the Helm chart

### DIFF
--- a/falcosidekick/Chart.yaml
+++ b/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.14.0
 description: A simple daemon to help you with falco's outputs
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick.png
 name: falcosidekick
-version: 0.1.21
+version: 0.1.22
 keywords:
   - monitoring
   - security

--- a/falcosidekick/templates/deployment.yaml
+++ b/falcosidekick/templates/deployment.yaml
@@ -22,6 +22,12 @@ spec:
         aadpodidbinding: {{ include "falcosidekick.fullname" . }}
         {{- end }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: {{ include "falcosidekick.fullname" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"

--- a/falcosidekick/values.yaml
+++ b/falcosidekick/values.yaml
@@ -9,6 +9,10 @@ image:
   tag: 2.13.0
   pullPolicy: IfNotPresent
 
+# One or more secrets to be used when pulling images
+imagePullSecrets: []
+# - registrySecretName
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
Signed-off-by: Armin armin@coralic.nl
What type of PR is this?

/kind feature
Any specific area of the project related to this PR?

/area helm

What this PR does / why we need it:

Adding the imagePullSecrets to the Helm deployments to allow authenticated Docker registries.