### PR TITLE
docs(falco-exporter): use falco-exporter in the example

### DIFF
--- a/falco-exporter/README.md
+++ b/falco-exporter/README.md
@@ -63,7 +63,7 @@ Please, refer to [values.yaml](./values.yaml) for the full list of configurable 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-helm install falco --set falco.jsonOutput=true falcosecurity/falco
+helm install falco-exporter --set falco.grpcTimeout=3m falcosecurity/falco-exporter
 ```
 
 Alternatively, a YAML file that specifies the parameters' values can be provided while installing the chart. For example,


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falco-exporter-chart

**What this PR does / why we need it**:

The Falco chart (instead of the falco-expoter chart) was used in an example within the README.md. This can lead people to confusion. This PR just fixes this small issue.
