### PR TITLE
Configure the pod security context in the Falco Sidekick Deployment

### DIFF
--- a/falcosidekick/CHANGELOG.md
+++ b/falcosidekick/CHANGELOG.md
@@ -5,6 +5,12 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick). 
 
+## 0.1.25
+
+### Minor Changes
+
+* Allow the configuration of the Pod securityContext, set default runAsUser and fsGroup values
+
 ## 0.1.24
 
 ### Minor Changes

--- a/falcosidekick/Chart.yaml
+++ b/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.14.0
 description: A simple daemon to help you with falco's outputs
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.1.24
+version: 0.1.25
 keywords:
   - monitoring
   - security

--- a/falcosidekick/templates/deployment.yaml
+++ b/falcosidekick/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      securityContext:
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/falcosidekick/values.yaml
+++ b/falcosidekick/values.yaml
@@ -9,6 +9,10 @@ image:
   tag: 2.13.0
   pullPolicy: IfNotPresent
 
+podSecurityContext:
+  runAsUser: 1234
+  fsGroup: 1234
+
 # One or more secrets to be used when pulling images
 imagePullSecrets: []
 # - registrySecretName


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

/kind chart-release

**Any specific area of the project related to this PR?**

/area falcosidekick

**What this PR does / why we need it**:

A pod security context is useful in EKS when we want to mount the ServiceAccount token and use it to get our AWS credentials. Without the fsGroup, the ServiceAccount token is not accessible in the container.

**Checklist**

- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
