### PR TITLE
Add SCC to support Openshift

### DIFF
--- a/falco-exporter/CHANGELOG.md
+++ b/falco-exporter/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to `falco-exporter` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.3.6
+
+### Minor Changes
+
+* Add SecurityContextConstraint to allow deploying in Openshift
+
 ## v0.3.5
 
 ### Minor Changes

--- a/falco-exporter/Chart.yaml
+++ b/falco-exporter/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.5
+version: 0.3.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/falco-exporter/README.md
+++ b/falco-exporter/README.md
@@ -60,6 +60,8 @@ The following table lists the main configurable parameters of the chart and thei
 | `serviceMonitor.scrapeTimeout`    | Specify a user defined scrape timeout for the Service Monitor                                    | `""`                               |
 | `grafanaDashboard.enabled`        | Enable the falco security dashboard, see https://github.com/falcosecurity/falco-exporter#grafana | `false`                            |
 | `grafanaDashboard.namespace`      | The namespace to deploy the dashboard configmap in                                               | `default`                          |
+| `scc.create`                      | Create OpenShift's Security Context Constraint                                                   | `true`                             |
+
 
 Please, refer to [values.yaml](./values.yaml) for the full list of configurable parameters.
 

--- a/falco-exporter/templates/securitycontextconstraints.yaml
+++ b/falco-exporter/templates/securitycontextconstraints.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.scc.create (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: |
+      This provides the minimum requirements Falco-exporter to run in Openshift.
+  name: {{ template "falco-exporter.fullname" . }}
+  labels:
+    {{- include "falco-exporter.labels" . | nindent 4 }}
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: []
+allowedUnsafeSysctls: []
+defaultAddCapabilities: []
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: 0
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ include "falco-exporter.serviceAccountName" . }}
+volumes:
+- hostPath
+- secret
+{{- end }}

--- a/falco-exporter/values.yaml
+++ b/falco-exporter/values.yaml
@@ -92,3 +92,7 @@ serviceMonitor:
 grafanaDashboard:
   enabled: false
   namespace: default
+
+scc:
+  # true here enabled creation of Security Context Constraints in Openshift
+  create: true


### PR DESCRIPTION
Similar to https://github.com/falcosecurity/charts/pull/51, add SCC support for Openshift, required to mounth the grpc socket as hostPath

Signed-off-by: Alvaro Iradier <airadier@gmail.com>

**What type of PR is this?**

/kind chart-release

/area falco-exporter-chart

**What this PR does / why we need it**:

The daemonset fails to create the pods in Openshift environment due to the request of HostPath mount, required to connect to Falco via GRPC.

This PR adds a SCC resource which is only created in Openshift (detected via API capabilities in the chart), and that can be disabled with scc.create: false in the values.yaml

**Checklist**
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
