### PR TITLE
falco-exporter: Added podSecurityPolicy configuration values

### DIFF
--- a/falco-exporter/CHANGELOG.md
+++ b/falco-exporter/CHANGELOG.md
@@ -3,6 +3,13 @@
 This file documents all notable changes to `falco-exporter` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.3.5
+
+### Minor Changes
+
+* Added the possibility to automatically add a PSP (in combination with a Role and a RoleBindung) via the podSecurityPolicy values
+* Namespaced the falco-exporter ServiceAccount and Service
+
 ## v0.3.4
 
 ### Minor Changes

--- a/falco-exporter/Chart.yaml
+++ b/falco-exporter/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.4
+version: 0.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/falco-exporter/README.md
+++ b/falco-exporter/README.md
@@ -52,10 +52,12 @@ The following table lists the main configurable parameters of the chart and thei
 | `image.pullPolicy`                | The image pull policy                                                                            | `IfNotPresent`                     |
 | `falco.grpcUnixSocketPath`        | Unix socket path for connecting to a Falco gRPC server                                           | `unix:///var/run/falco/falco.sock` |
 | `falco.grpcTimeout`               | gRPC connection timeout                                                                          | `2m`                               |
+| `serviceAccount.create`           | Specify if a service account should be created                                                   | `true`                             |
+| `podSecurityPolicy.create`        | Specify if a PSP, Role & RoleBinding should be created                                           | `true`                             |
 | `serviceMonitor.enabled`          | Enabled deployment of a Prometheus operator Service Monitor                                      | `false`                            |
 | `serviceMonitor.additionalLabels` | Add additional Labels to the Service Monitor                                                     | `{}`                               |
 | `serviceMonitor.interval`         | Specify a user defined interval for the Service Monitor                                          | `""`                               |
-| `serviceMonitor.scrapeTimeout`    | Specify a user defined scrape timeout for the Service Monitor                                    | `""`                               |  |
+| `serviceMonitor.scrapeTimeout`    | Specify a user defined scrape timeout for the Service Monitor                                    | `""`                               |
 | `grafanaDashboard.enabled`        | Enable the falco security dashboard, see https://github.com/falcosecurity/falco-exporter#grafana | `false`                            |
 | `grafanaDashboard.namespace`      | The namespace to deploy the dashboard configmap in                                               | `default`                          |
 

--- a/falco-exporter/README.md
+++ b/falco-exporter/README.md
@@ -53,7 +53,7 @@ The following table lists the main configurable parameters of the chart and thei
 | `falco.grpcUnixSocketPath`        | Unix socket path for connecting to a Falco gRPC server                                           | `unix:///var/run/falco/falco.sock` |
 | `falco.grpcTimeout`               | gRPC connection timeout                                                                          | `2m`                               |
 | `serviceAccount.create`           | Specify if a service account should be created                                                   | `true`                             |
-| `podSecurityPolicy.create`        | Specify if a PSP, Role & RoleBinding should be created                                           | `true`                             |
+| `podSecurityPolicy.create`        | Specify if a PSP, Role & RoleBinding should be created                                           | `false`                            |
 | `serviceMonitor.enabled`          | Enabled deployment of a Prometheus operator Service Monitor                                      | `false`                            |
 | `serviceMonitor.additionalLabels` | Add additional Labels to the Service Monitor                                                     | `{}`                               |
 | `serviceMonitor.interval`         | Specify a user defined interval for the Service Monitor                                          | `""`                               |

--- a/falco-exporter/templates/_helpers.tpl
+++ b/falco-exporter/templates/_helpers.tpl
@@ -67,6 +67,17 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Create the name of the PSP to use
+*/}}
+{{- define "falco-exporter.podSecurityPolicyName" -}}
+{{- if .Values.podSecurityPolicy.create -}}
+    {{ default (include "falco-exporter.fullname" .) .Values.podSecurityPolicy.name }}
+{{- else -}}
+    {{ default "default" .Values.podSecurityPolicy.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Extract the unixSocket's directory path
 */}}
 {{- define "falco-exporter.unixSocketDir" -}}

--- a/falco-exporter/templates/_helpers.tpl
+++ b/falco-exporter/templates/_helpers.tpl
@@ -85,3 +85,14 @@ Extract the unixSocket's directory path
 {{- .Values.falco.grpcUnixSocketPath | trimPrefix "unix://" | dir -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for rbac.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/falco-exporter/templates/daemonset.yaml
+++ b/falco-exporter/templates/daemonset.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "falco-exporter.fullname" . }}
   labels:
     {{- include "falco-exporter.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/falco-exporter/templates/podsecuritypolicy.yaml
+++ b/falco-exporter/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podSecurityPolicy.create -}}
+{{- if and .Values.podSecurityPolicy.create (.Capabilities.APIVersions.Has "policy/v1beta1") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/falco-exporter/templates/podsecuritypolicy.yaml
+++ b/falco-exporter/templates/podsecuritypolicy.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.podSecurityPolicy.create -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "falco-exporter.podSecurityPolicyName" . }}
+  labels:
+    {{- include "falco-exporter.labels" . | nindent 4 }}
+  {{- with .Values.podSecurityPolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  allowPrivilegeEscalation: false
+  allowedHostPaths:
+  - pathPrefix: "/var/run/falco"
+    readOnly: true
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - 'hostPath'
+{{- end -}}

--- a/falco-exporter/templates/role.yaml
+++ b/falco-exporter/templates/role.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.podSecurityPolicy.create -}}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ include "falco-exporter.podSecurityPolicyName" . }}
+  labels:
+    {{- include "falco-exporter.labels" . | nindent 4 }}
+  {{- with .Values.podSecurityPolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - {{ include "falco-exporter.podSecurityPolicyName" . }}
+    verbs:
+      - use
+{{- end -}}

--- a/falco-exporter/templates/role.yaml
+++ b/falco-exporter/templates/role.yaml
@@ -11,12 +11,12 @@ metadata:
   {{- end }}
   namespace: {{ .Release.Namespace }}
 rules:
-  - apiGroups:
-      - extensions
-    resources:
-      - podsecuritypolicies
-    resourceNames:
-      - {{ include "falco-exporter.podSecurityPolicyName" . }}
-    verbs:
-      - use
+- apiGroups:
+    - extensions
+  resources:
+    - podsecuritypolicies
+  resourceNames:
+    - {{ include "falco-exporter.podSecurityPolicyName" . }}
+  verbs:
+    - use
 {{- end -}}

--- a/falco-exporter/templates/role.yaml
+++ b/falco-exporter/templates/role.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.podSecurityPolicy.create -}}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   name: {{ include "falco-exporter.podSecurityPolicyName" . }}
   labels:

--- a/falco-exporter/templates/rolebinding.yaml
+++ b/falco-exporter/templates/rolebinding.yaml
@@ -11,8 +11,8 @@ metadata:
   {{- end }}
   namespace: {{ .Release.Namespace }}
 subjects:
-  - kind: ServiceAccount
-    name: {{ include "falco-exporter.podSecurityPolicyName" . }}
+- kind: ServiceAccount
+  name: {{ include "falco-exporter.podSecurityPolicyName" . }}
 roleRef:
   kind: Role
   name: {{ include "falco-exporter.podSecurityPolicyName" . }}

--- a/falco-exporter/templates/rolebinding.yaml
+++ b/falco-exporter/templates/rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.podSecurityPolicy.create -}}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ include "falco-exporter.podSecurityPolicyName" . }}
+  labels:
+    {{- include "falco-exporter.labels" . | nindent 4 }}
+  {{- with .Values.podSecurityPolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "falco-exporter.podSecurityPolicyName" . }}
+roleRef:
+  kind: Role
+  name: {{ include "falco-exporter.podSecurityPolicyName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/falco-exporter/templates/rolebinding.yaml
+++ b/falco-exporter/templates/rolebinding.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "falco-exporter.podSecurityPolicyName" . }}
+  name: {{ include "falco-exporter.serviceAccountName" . }}
 roleRef:
   kind: Role
   name: {{ include "falco-exporter.podSecurityPolicyName" . }}

--- a/falco-exporter/templates/rolebinding.yaml
+++ b/falco-exporter/templates/rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.podSecurityPolicy.create -}}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   name: {{ include "falco-exporter.podSecurityPolicyName" . }}
   labels:

--- a/falco-exporter/templates/service.yaml
+++ b/falco-exporter/templates/service.yaml
@@ -11,6 +11,7 @@ metadata:
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
+  namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}

--- a/falco-exporter/templates/serviceaccount.yaml
+++ b/falco-exporter/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/falco-exporter/values.yaml
+++ b/falco-exporter/values.yaml
@@ -34,6 +34,16 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  # If set and create is false, an already existing serviceAccount must be provided.
+  name:
+
+podSecurityPolicy:
+  # Specifies whether a PSP, Role and RoleBinding should be created
+  create: true
+  # Annotations to add to the PSP, Role and RoleBinding
+  annotations: {}
+  # The name of the PSP, Role and RoleBinding to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
 

--- a/falco-exporter/values.yaml
+++ b/falco-exporter/values.yaml
@@ -40,7 +40,7 @@ serviceAccount:
 
 podSecurityPolicy:
   # Specifies whether a PSP, Role and RoleBinding should be created
-  create: true
+  create: false
   # Annotations to add to the PSP, Role and RoleBinding
   annotations: {}
   # The name of the PSP, Role and RoleBinding to use.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falco-exporter-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR implements the possibility to automatically create a proper working PSP, Role and RoleBinding for a Helm based falco-exporter deployment. It also fixes the namespace assignment of the falco-exporter Service and ServiceAccount object which would not have been assigned to a specific namespace.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes https://github.com/falcosecurity/charts/issues/103

**Special notes for your reviewer**:
I also made a new release `v0.3.5` with the regarding release nodes. The deployment was tested on Minikube `v1.13.0` with the following commands:
```bash
⋊> ~/G/charts on master ◦ k create ns k8s-security
⋊> ~/G/charts on master ◦ helm install falco -n k8s-security --set falco.jsonOutput=true --set falco.grpc.enabled=true ./falco
⋊> ~/G/charts on master ◦ helm install falco-exporter ./falco-exporter -n k8s-security
⋊> ~/G/charts on master ◦ kgp -n k8s-security
NAME                   READY   STATUS    RESTARTS   AGE
falco-exporter-jcwrm   1/1     Running   3          21m
falco-xjq6w            1/1     Running   0          14m
⋊> ~/G/charts on master ◦ k logs -n k8s-security falco-exporter-jcwrm
2020/10/04 16:50:16 connecting to gRPC server at unix:///var/run/falco/falco.sock (timeout 2m0s)
2020/10/04 16:50:16 listening on 0.0.0.0:9376/metrics
2020/10/04 16:50:22 connected to gRPC server, subscribing events stream
2020/10/04 16:50:22 ready
```

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] CHANGELOG.md updated
