### PR TITLE
fix(build): wait for releases to be ready

### DIFF
--- a/.circleci/release.sh
+++ b/.circleci/release.sh
@@ -50,6 +50,10 @@ main() {
         done
 
         release_charts
+
+        # the newly created GitHub releases may not be available yet; let's wait a bit to be sure.
+        sleep 5
+
         update_index
     else
         echo "Nothing to do. No chart changes detected."


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**


**What this PR does / why we need it**:

It happened several times that the release job failed just because the release was not found by GitHub API immediately after it had been created.
Some examples from the CI logs:
https://app.circleci.com/pipelines/github/falcosecurity/charts/120/workflows/fb349a0a-0f37-4ce7-b666-64854990aa6d/jobs/112
https://app.circleci.com/pipelines/github/falcosecurity/charts/120/workflows/9e467708-649a-463f-af0c-732b213b06a0/jobs/110
https://app.circleci.com/pipelines/github/falcosecurity/charts/114/workflows/bb91e320-84f4-4726-a365-93bafeaf8f30/jobs/105

Then I noticed that even though the logs reported:
```
Successfully packaged chart and saved it to: .cr-release-packages/falco-exporter-0.3.5.tgz
====> Using existing index at .cr-index/index.yaml
Error: GET https://api.github.com/repos/falcosecurity/charts/releases/tags/falco-exporter-0.3.5: 404 Not Found []
```
after a while, the GitHub API started to return the release metadata correctly. That let me think that maybe GitHub is processing new releases asynchronously. 

For the above reason, this PR introduces a 5-seconds sleeping step as a workaround.
If it works, we can later find a better strategy to deal with this problem.


