### PR TITLE
Replace extensions apiGroup/apiVersion because of deprecation

### DIFF
--- a/falco-exporter/CHANGELOG.md
+++ b/falco-exporter/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to `falco-exporter` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.3.8
+
+### Minor Changes
+
+* Replace extensions apiGroup/apiVersion because of deprecation
+
 ## v0.3.7
 
 ### Minor Changes

--- a/falco-exporter/Chart.yaml
+++ b/falco-exporter/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.7
+version: 0.3.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/falco-exporter/templates/role.yaml
+++ b/falco-exporter/templates/role.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
-    - extensions
+    - policy
   resources:
     - podsecuritypolicies
   resourceNames:

--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.5.1
+
+### Minor Changes
+
+* Replace extensions apiGroup/apiVersion because of deprecation
+
 ## v1.5.0
 
 ### Minor Changes

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 1.5.0
+version: 1.5.1
 appVersion: 0.26.1
 description: Falco
 keywords:

--- a/falco/templates/clusterrole.yaml
+++ b/falco/templates/clusterrole.yaml
@@ -45,7 +45,7 @@ rules:
       - get
 {{- if .Values.podSecurityPolicy.create }}
   - apiGroups:
-      - extensions
+      - policy
     resources:
       - podsecuritypolicies
     resourceNames:

--- a/falcosidekick/CHANGELOG.md
+++ b/falcosidekick/CHANGELOG.md
@@ -5,6 +5,12 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick). 
 
+## 0.1.27
+
+### Minor Changes
+
+* Replace extensions apiGroup/apiVersion because of deprecation
+
 ## 0.1.26
 
 ### Minor Changes

--- a/falcosidekick/Chart.yaml
+++ b/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.14.0
 description: A simple daemon to help you with falco's outputs
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.1.26
+version: 0.1.27
 keywords:
   - monitoring
   - security

--- a/falcosidekick/templates/clusterrole.yaml
+++ b/falcosidekick/templates/clusterrole.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
   - apiGroups:
-      - extensions
+      - policy
     resources:
       - podsecuritypolicies
     resourceNames:

--- a/falcosidekick/templates/ingress.yaml
+++ b/falcosidekick/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "falcosidekick.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
Deprecation Info:
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

Signed-off-by: Christian Zunker <christian.zunker@codecentric.cloud>

**What type of PR is this?**

/kind bug

/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-chart
/area falco-exporter-chart
/area falcosidekick

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] CHANGELOG.md updated
