### PR TITLE
falco/ci: Set values to deploy falco on ci

### DIFF
--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 1.5.6
+version: 1.5.7
 appVersion: 0.26.2
 description: Falco
 keywords:

--- a/falco/ci/ci-values.yaml
+++ b/falco/ci/ci-values.yaml
@@ -1,0 +1,5 @@
+# CI values for Falco.
+# To deploy Falco on CI we need to set an argument to bypass the installation
+# of the kernel module, so we bypass that.
+extraArgs:
+  - --userspace


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

If install Falco using the default configuration it will try to install the kernel module which is not available in CI, to avoid any issues we can use a custom value to test on CI.

The custom value sets the `--userspace` and with that does not install the kernel module

/assign @leogr 

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] CHANGELOG.md updated
