### PR TITLE
feat(falco): allow adding additional volumes and volumeMounts to falco daemonset

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,13 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.5.8
+
+### Minor Changes
+
+* Add value `extraVolumes`, allow adding extra volumes to falco daemonset
+* Add value `extraVolumeMounts`, allow adding extra volumeMounts to falco container in falco daemonset
+
 ## v1.5.6
 
 ### Minor Changes

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 1.5.7
+version: 1.5.8
 appVersion: 0.26.2
 description: Falco
 keywords:

--- a/falco/README.md
+++ b/falco/README.md
@@ -124,9 +124,10 @@ The following table lists the configurable parameters of the Falco chart and the
 | `nodeSelector`                                  | The node selection constraint                                                                                      | `{}`                                                                                                                                      |
 | `affinity`                                      | The affinity constraint                                                                                            | `{}`                                                                                                                                      |
 | `tolerations`                                   | The tolerations for scheduling                                                                                     | `node-role.kubernetes.io/master:NoSchedule`                                                                                               |
-| `scc.create`                                    | Create OpenShift's Security Context Constraint                                                                     | `true` 
-| `extraInitContainers`                           | A list of initContainers you want to add to the falco pod in the daemonset.                                        | `[]`
-                                                  |
+| `scc.create`                                    | Create OpenShift's Security Context Constraint                                                                     | `true`                                                                                                                                    |
+| `extraInitContainers`                           | A list of initContainers you want to add to the falco pod in the daemonset.                                        | `[]`                                                                                                                                      |
+| `extraVolumes`                                  | A list of volumes you want to add to the falco daemonset.                                                          | `[]`                                                                                                                                      |
+| `extraVolumeMounts`                             | A list of volumeMounts you want to add to the falco container in the falco daemonset.                              | `[]`                                                                                                                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/falco/templates/daemonset.yaml
+++ b/falco/templates/daemonset.yaml
@@ -145,6 +145,9 @@ spec:
               name: certs-volume
               readOnly: true
             {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 12 }}
+            {{- end }}
       {{- if .Values.integrations.natsOutput.enabled }}
         - name: {{ .Chart.Name }}-nats
           image: sysdig/falco-nats:latest
@@ -289,6 +292,9 @@ spec:
                 path: server.pem
               - key: ca.crt
                 path: ca.crt
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
         {{- end }}
   updateStrategy:
 {{ toYaml .Values.daemonset.updateStrategy | indent 4 }}

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -106,6 +106,7 @@ falco:
     - /etc/falco/falco_rules.local.yaml
     - /etc/falco/k8s_audit_rules.yaml
     - /etc/falco/rules.d
+  # - /etc/falco/rules.optional.d
 
   # If true, the times displayed in log messages and output messages
   # will be in ISO 8601. By default, times are displayed in the local
@@ -272,7 +273,8 @@ falco:
   grpcOutput:
     enabled: false
 
-customRules: {}
+customRules:
+  {}
   # Although Falco comes with a nice default rule set for detecting weird
   # behavior in containers, our users are going to customize the run-time
   # security rule sets or policies for the specific container images and
@@ -321,7 +323,6 @@ integrations:
     aws_secret_access_key: ""
     aws_default_region: ""
 
-
   # If GCloud Pub/Sub integration is enabled, Falco will be configured to use this
   # integration as file_output and sets the following values:
   # * json_output: true
@@ -336,7 +337,6 @@ integrations:
     credentialsData: ""
     projectID: ""
 
-
 # certificates used by webserver and grpc server
 # paste certificate content or use helm with --set-file
 certs:
@@ -345,7 +345,6 @@ certs:
     crt: ""
   ca:
     crt: ""
-
 
 # Allow Falco to run on Kubernetes 1.6 masters.
 tolerations:
@@ -358,3 +357,18 @@ scc:
 
 # Add initContainers to Falco pod
 extraInitContainers: []
+
+# Add extra volumes to Falco daemonset
+extraVolumes: []
+# - name: optional-rules-volume
+#   configMap:
+#     name: falco-rules-optional
+#     optional: true
+#     items:
+#       - key: falco_rules.optional.yaml
+#         path: falco_rules.optional.yaml
+
+# Add extra volumeMounts to Falco container in Falco daemonset
+extraVolumeMounts: []
+# - mountPath: /etc/falco/rules.optional.d
+#   name: optional-rules-volume


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

This PR makes it possible to add additional volumes and volumeMounts to the falco daemonset. In my particular use-case, I might want to mount optional rules from an existing configMap.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**Checklist**

- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] CHANGELOG.md updated
