### PR TITLE
add falcosidekick as optional dependency for falco

### DIFF
--- a/falco/.gitignore
+++ b/falco/.gitignore
@@ -1,0 +1,2 @@
+charts
+requirements.lock

--- a/falco/.gitignore
+++ b/falco/.gitignore
@@ -1,2 +1,2 @@
-charts
 requirements.lock
+Chart.lock

--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.6.1
+
+### Minor Changes
+
+* Add `falcosidekick` as an optional dependency
+
 ## v1.6.0
 
 ### Minor Changes

--- a/falco/Chart.lock
+++ b/falco/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: falcosidekick
+  repository: https://falcosecurity.github.io/charts
+  version: 0.2.2
+digest: sha256:417f3b972f4655b5ade1809e915298037f739c910b07f78ada41dbe0b865da7a
+generated: "2021-01-14T17:59:11.091552+01:00"

--- a/falco/Chart.lock
+++ b/falco/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: falcosidekick
-  repository: https://falcosecurity.github.io/charts
-  version: 0.2.2
-digest: sha256:417f3b972f4655b5ade1809e915298037f739c910b07f78ada41dbe0b865da7a
-generated: "2021-01-14T17:59:11.091552+01:00"

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -18,8 +18,7 @@ maintainers:
   - name: The Falco Authors
     email: cncf-falco-dev@lists.cncf.io
 dependencies:
-  - alias: falcosidekick
-    name: falcosidekick
-    version: 0.2.2
+  - name: falcosidekick
+    version: "0.2.*"
     condition: falcosidekick.enabled
     repository: https://falcosecurity.github.io/charts

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v1
+apiVersion: v2
 name: falco
-version: 1.6.0
+version: 1.6.1
 appVersion: 0.26.2
 description: Falco
 keywords:
@@ -17,3 +17,9 @@ sources:
 maintainers:
   - name: The Falco Authors
     email: cncf-falco-dev@lists.cncf.io
+dependencies:
+  - alias: falcosidekick
+    name: falcosidekick
+    version: 0.2.2
+    condition: falcosidekick.enabled
+    repository: https://falcosecurity.github.io/charts

--- a/falco/README.md
+++ b/falco/README.md
@@ -128,6 +128,7 @@ The following table lists the configurable parameters of the Falco chart and the
 | `extraInitContainers`                           | A list of initContainers you want to add to the falco pod in the daemonset.                                        | `[]`                                                                                                                                      |
 | `extraVolumes`                                  | A list of volumes you want to add to the falco daemonset.                                                          | `[]`                                                                                                                                      |
 | `extraVolumeMounts`                             | A list of volumeMounts you want to add to the falco container in the falco daemonset.                              | `[]`                                                                                                                                      |
+| `falcosidekick.enable`                             | Enable `falcosidekick` deployment                              | `false`                                                                                                                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/falco/templates/NOTES.txt
+++ b/falco/templates/NOTES.txt
@@ -1,6 +1,7 @@
 Falco agents are spinning up on each node in your cluster. After a few
 seconds, they are going to start monitoring your containers looking for
 security issues.
+{{printf "\n" }}
 
 {{- if .Values.integrations }}
 WARNING: The following integrations have been deprecated and removed
@@ -8,6 +9,16 @@ WARNING: The following integrations have been deprecated and removed
  - natsOutput
  - snsOutput
  - pubsubOutput
+Consider to use falcosidekick (https://github.com/falcosecurity/falcosidekick) as replacement.
 {{- else }}
 No further action should be required.
 {{- end }}
+{{printf "\n" }}
+
+{{- if not .Values.falcosidekick.enabled }}
+Tip: 
+You can easily forward falco events to Slack, Kafka, AWS Lambda and more with falcosidekick. 
+Full list of outputs: https://github.com/falcosecurity/charts/falcosidekick.
+You can enable its deployment with `--set falcosidekick.enabled=true` or in your values.yaml. 
+See: https://github.com/falcosecurity/charts/blob/master/falcosidekick/values.yaml for configuration values.
+{{- end}}

--- a/falco/templates/configmap.yaml
+++ b/falco/templates/configmap.yaml
@@ -33,13 +33,21 @@ data:
     time_format_iso_8601: {{ .Values.falco.timeFormatISO8601 }}
 
     # Whether to output events in json or text
+    {{- if .Values.falcosidekick.enabled }}
+    json_output: true
+    {{- else }}
     json_output: {{ .Values.falco.jsonOutput }}
+    {{- end }}
 
     # When using json output, whether or not to include the "output" property
     # itself (e.g. "File below a known binary directory opened for writing
     # (user=root ....") in the json output.
 
+    {{- if .Values.falcosidekick.enabled }}
+    json_include_output_property: true
+    {{- else }}
     json_include_output_property: {{ .Values.falco.jsonIncludeOutputProperty }}
+    {{- end }}
 
     # Send information logs to stderr and/or syslog Note these are *not* security
     # notification logs! These are just Falco lifecycle (and possibly error) logs.
@@ -159,8 +167,8 @@ data:
 {{ .Values.falco.programOutput.program | indent 8 }}
 
     http_output:
-      enabled: {{ .Values.falco.httpOutput.enabled }}
-      url: {{ .Values.falco.httpOutput.url }}
+      enabled: {{ if .Values.falcosidekick.enabled }}true{{ else }}{{ .Values.falco.httpOutput.enabled }}{{ end }}
+      url: {{ if .Values.falcosidekick.enabled }}http://falcosidekick:{{ .Values.falcosidekick.listenport | default "2801" }}{{ else }}{{ .Values.falco.httpOutput.url }}{{ end }}
 
     grpc:
       enabled: {{ .Values.falco.grpc.enabled }}

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -320,3 +320,8 @@ extraVolumes: []
 extraVolumeMounts: []
 # - mountPath: /etc/falco/rules.optional.d
 #   name: optional-rules-volume
+
+falcosidekick:
+  # enable falcosidekick deployment
+  enabled: false
+  # for configuration values, see https://github.com/falcosecurity/charts/blob/master/falcosidekick/values.yaml


### PR DESCRIPTION
Signed-off-by: Issif <issif_github@gadz.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area falco-chart

> /area falco-exporter-chart

/area falcosidekick-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds `falcosidekick` chart as an optionnal dependency for `falco` chart. It means we can deploy together `falco` and `falcosidekick`.

A message at end of deployment of `falco` has also been added for promoting usage of `falcosidekick` and how to deploy it.

```
$ helm install falco . -n falco

Release "falco" has been upgraded. Happy Helming!
NAME: falco
LAST DEPLOYED: Wed Jan 13 23:52:46 2021
NAMESPACE: falco
STATUS: deployed
REVISION: 8
TEST SUITE: None
NOTES:
Falco agents are spinning up on each node in your cluster. After a few
seconds, they are going to start monitoring your containers looking for
security issues.

No further action should be required.

Tip: 
You can easily forward falco events to Slack, Kafka, AWS Lambda and more with falcosidekick. 
Full list of outputs: https://github.com/falcosecurity/charts/falcosidekick.
You can enable its deployment with `--set falcosidekick.enabled=true` or in your values.yaml. 
See: https://github.com/falcosecurity/charts/blob/master/falcosidekick/values.yaml for configuration values.
```

This message is not displayed if `falcosidekick` is deployed:

```
$ helm upgrade falco --set falcosidekick.enabled=true . -n falcoRelease "falco" has been upgraded. 
Happy Helming!
NAME: falco
LAST DEPLOYED: Wed Jan 13 23:53:51 2021
NAMESPACE: falco
STATUS: deployed
REVISION: 9
NOTES:
Falco agents are spinning up on each node in your cluster. After a few
seconds, they are going to start monitoring your containers looking for
security issues.

No further action should be required.
```

In the same time, the configmap for `falco` is automatically configured for using `falcosidekick` as output for `falco`:

```yaml
http_output:
  enabled: true
  url: http://falcosidekick:2801
```

**Which issue(s) this PR fixes**:

N/A

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

This PR is a proposal, this is why I haven't not bumped up the chart version yet. If everybody agrees, I will do it and squash commits.

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
