### PR TITLE
Only show non-zero rates in Grafana

### DIFF
--- a/falco-exporter/CHANGELOG.md
+++ b/falco-exporter/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to `falco-exporter` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.5.1
+
+* Display only non-zero rates in Grafana dashboard template
+
 ## v0.5.0
 
 ### Minor Changes

--- a/falco-exporter/Chart.yaml
+++ b/falco-exporter/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/falco-exporter/templates/grafana-dashboard.yaml
+++ b/falco-exporter/templates/grafana-dashboard.yaml
@@ -80,7 +80,7 @@ data:
             },
             "lines": true,
             "linewidth": 1,
-            "nullPointMode": "null",
+            "nullPointMode": "null as zero",
             "options": {
               "dataLinks": []
             },
@@ -94,7 +94,7 @@ data:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "rate(falco_events[5m])",
+                "expr": "rate(falco_events[5m]) > 0",
                 "interval": "",
                 "intervalFactor": 1,
                 "legendFormat": "{{`{{rule}} (node=\"{{kubernetes_node}}\",ns=\"{{k8s_ns_name}}\",pod=\"{{k8s_pod_name}}\")"`}},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug
/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falco-exporter-chart

**What this PR does / why we need it**:

Adjust Grafana dashboard to only show events with non-zero rate.

Currently where there are large numbers of alerts that have previously fired, these are exported to Prometheus and therefore show in the graph legend making it difficult to read.

With this change, alerts now only shows in the legend if they have occurred within the time range for the dashboard.

**Special notes for your reviewer**:

**Checklist**

- [x] Chart Version bumped
- [x] CHANGELOG.md updated
