### PR TITLE
Updating the location of the falco icon

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,9 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.7.6
+
+* Correct icon URL
 ## v1.7.5
 
 * Update downstream sidekick chart

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - troubleshooting
   - run-time
 home: https://falco.org
-icon: https://falco.org/images/logos/falco-logo.png
+icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/falco/horizontal/color/falco-horizontal-color.svg
 sources:
   - https://github.com/falcosecurity/falco
 maintainers:

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 1.7.5
+version: 1.7.6
 appVersion: 0.27.0
 description: Falco
 keywords:


### PR DESCRIPTION
The previous location specified for the icon is returning a 404
not found error. The new location is where the CNCF keeps the
artwork.

This was noticed on the artifact hub as it was no longer able to
pull the image.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #192

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] CHANGELOG.md updated
