### PR TITLE
Add link on GH Pages to charts' repo Readme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,8 @@
 <html>
     <body>
-        <h1>Falco Community <a href="https://github.com/falcosecurity/charts">Charts</a></h1>
+        <h1><a href="https://github.com/falcosecurity/falco/">Falco</a> Community <a href="https://github.com/falcosecurity/charts">Charts</a></h1>
         <h2>Helm charts for installing Falco and components</h2>
-        <ul>
-            <li><a href="https://github.com/falcosecurity/falco/">Falco</a></li>
-        </ul>
+        <h3>For more info, please read <a href="https://github.com/falcosecurity/charts/blob/master/README.md">here</a>.
         <h4> <a href="https://falcosecurity.github.io/charts/index.yaml">Raw Index File </a></h4>
     </body>
 </html>


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**Any specific area of the project related to this PR?**

/area gh-pages

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This small PR adds link to this repo `README` file, for up-to-date information about which charts are available, instead of listing only the Falco chart.