### PR TITLE
build(.circleci): do not run charts job on `gh-pages` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,19 +12,19 @@ jobs:
             shellcheck -x .circleci/release.sh
   lint-charts:
     docker:
-        - image: quay.io/helmpack/chart-testing:latest
+      - image: quay.io/helmpack/chart-testing:latest
     steps:
       - checkout
       - run:
           name: lint
           command: ct lint --config tests/ct.yaml
   install-charts:
-      machine: true
-      steps:
-        - checkout
-        - run:
-            command: tests/e2e-kind.sh
-            no_output_timeout: 1h
+    machine: true
+    steps:
+      - checkout
+      - run:
+          command: tests/e2e-kind.sh
+          no_output_timeout: 1h
   release-charts:
     docker:
       - image: cimg/base:stable
@@ -46,9 +46,18 @@ workflows:
   version: 2
   release:
     jobs:
-      - lint-scripts
-      - lint-charts
+      - lint-scripts:
+          filters:
+            branches:
+              ignore: gh-pages
+      - lint-charts:
+          filters:
+            branches:
+              ignore: gh-pages
       - install-charts:
+          filters:
+            branches:
+              ignore: gh-pages
           requires:
             - lint-scripts
             - lint-charts


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

Those jobs are not expected to run on the [gh-pages](https://github.com/falcosecurity/charts/tree/gh-pages) branch

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] CHANGELOG.md updated
