### PR TITLE
fix falcosidekick statsd config in secret

### DIFF
--- a/falcosidekick/CHANGELOG.md
+++ b/falcosidekick/CHANGELOG.md
@@ -10,7 +10,8 @@ Before release 0.1.20, the helm chart can be found in `falcosidekick` [repositor
 ### Fixes
 
 * Add config checksum annotation to deployment pods to restart pods on config change
-* Fix statsd config options in the secret to make them match the docs 
+* Fix statsd config options in the secret to make them match the docs
+
 ## 0.3.1
 
 ### Fixes

--- a/falcosidekick/CHANGELOG.md
+++ b/falcosidekick/CHANGELOG.md
@@ -5,6 +5,12 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.3.2
+
+### Fixes
+
+* Add config checksum annotation to deployment pods to restart pods on config change
+* Fix statsd config options in the secret to make them match the docs 
 ## 0.3.1
 
 ### Fixes

--- a/falcosidekick/Chart.yaml
+++ b/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.21.0
 description: A simple daemon to help you with falco's outputs
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.3.1
+version: 0.3.2
 keywords:
   - monitoring
   - security

--- a/falcosidekick/templates/deployment.yaml
+++ b/falcosidekick/templates/deployment.yaml
@@ -23,8 +23,9 @@ spec:
         {{- if and .Values.config.azure.podIdentityClientID .Values.config.azure.podIdentityName }}
         aadpodidbinding: {{ include "falcosidekick.fullname" . }}
         {{- end }}
-      {{- if .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:

--- a/falcosidekick/templates/secrets.yaml
+++ b/falcosidekick/templates/secrets.yaml
@@ -134,7 +134,8 @@ data:
   STAN_MINIMUMPRIORITY: "{{ .Values.config.stan.minimumpriority | b64enc }}"
 
   # Statsd
-  STATSD_FORESPACE: "{{ .Values.config.statsd.namespace | b64enc }}"
+  STATSD_FORWARDER: "{{ .Values.config.statsd.forwarder | b64enc }}"
+  STATSD_NAMESPACE: "{{ .Values.config.statsd.namespace | b64enc }}"
 
   # Dogstatsd
   DOGSTATSD_FORWARDER: "{{ .Values.config.dogstatsd.forwarder | b64enc }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind chart-release

**Any specific area of the project related to this PR?**

/area falcosidekick-chart


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

The statsd config options not being correctly set in the secret.
It also adds a [config checksum](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments) to the deployment pods, so that on config change falco sidekick will restart.

**Checklist**

- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
