### PR TITLE
Add missing imagePullSecrets in falcosidekick/templates/deployment-ui.yaml

### DIFF
--- a/falcosidekick/CHANGELOG.md
+++ b/falcosidekick/CHANGELOG.md
@@ -5,6 +5,12 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.3.9
+
+### Fixes
+
+* Add missing `imagePullSecrets` in `falcosidekick/templates/deployment-ui.yaml`
+
 ## 0.3.8
 
 ### Major Changes

--- a/falcosidekick/Chart.yaml
+++ b/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.23.1
 description: A simple daemon to help you with falco's outputs
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.3.8
+version: 0.3.9
 keywords:
   - monitoring
   - security

--- a/falcosidekick/templates/deployment-ui.yaml
+++ b/falcosidekick/templates/deployment-ui.yaml
@@ -22,6 +22,12 @@ spec:
         app.kubernetes.io/name: {{ include "falcosidekick.name" . }}-ui
         app.kubernetes.io/instance: {{ .Release.Name }}-ui
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       {{- if .Values.webui.priorityClassName }}
       priorityClassName: "{{ .Values.webui.priorityClassName }}"
       {{- end }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/area falcosidekick-chart

**What this PR does / why we need it**:

Adds `imagePullSecrets` to `deployment-ui.yaml` allowing to pull the image from a private repo with authentication.

**Which issue(s) this PR fixes**:

The key `imagePullSecrets` are configurable within the values, but not evaluated within the `deployment-ui.yaml` template.

**Special notes for your reviewer**:

**Checklist**
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] CHANGELOG.md updated
