### PR TITLE
Fix readiness and liveness probes scheme when ssl is enabled

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.15.1
+
+* Fixed liveness and readiness probes schema when ssl is enabled
+
 ## v1.14.1
 
 * Update `Falcosidekick` chart to 0.3.8

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 1.15.0
+version: 1.15.1
 appVersion: 0.29.0
 description: Falco
 keywords:

--- a/falco/templates/daemonset.yaml
+++ b/falco/templates/daemonset.yaml
@@ -64,11 +64,11 @@ spec:
             - --cri
             - /run/containerd/containerd.sock
             {{- end }}
-            {{- if .Values.kubernetesSupport.enabled }} 
+            {{- if .Values.kubernetesSupport.enabled }}
             - -K
-            - {{ .Values.kubernetesSupport.apiAuth }} 
+            - {{ .Values.kubernetesSupport.apiAuth }}
             - -k
-            - {{ .Values.kubernetesSupport.apiUrl }} 
+            - {{ .Values.kubernetesSupport.apiUrl }}
             {{- end }}
             - -pk
         {{- if .Values.extraArgs }}
@@ -107,6 +107,9 @@ spec:
             httpGet:
               path: {{ .Values.falco.webserver.k8sHealthzEndpoint }}
               port: {{ .Values.falco.webserver.listenPort }}
+              {{- if .Values.falco.webserver.sslEnabled }}
+              scheme: HTTPS
+              {{- end }}
           readinessProbe:
             initialDelaySeconds: {{ .Values.falco.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.falco.readinessProbe.timeoutSeconds }}
@@ -114,6 +117,9 @@ spec:
             httpGet:
               path: {{ .Values.falco.webserver.k8sHealthzEndpoint }}
               port: {{ .Values.falco.webserver.listenPort }}
+              {{- if .Values.falco.webserver.sslEnabled }}
+              scheme: HTTPS
+              {{- end }}
           {{- end }}
           volumeMounts:
             {{- if .Values.docker.enabled }}


### PR DESCRIPTION
Signed-off-by: Erwan Miran <mirwan666@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

When `falco.webserver.sslEnabled` is true, readiness and liveness probes fail as performed with http scheme (default)

**Which issue(s) this PR fixes**:

None that I know of

**Special notes for your reviewer**:

I didn't check the "Variables are documented in the README.md" item as no change has been made. Don't know if that was wrong...

**Checklist**

- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] CHANGELOG.md updated
