### PR TITLE
feat(falcosidekick)!: support Ingress API version networking.k8s.io/v1

### DIFF
--- a/falcosidekick/CHANGELOG.md
+++ b/falcosidekick/CHANGELOG.md
@@ -5,6 +5,12 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.4.0
+
+### Major Changes
+
+* Support Ingress API version `networking.k8s.io/v1`, see `ingress.hosts` and `webui.ingress.hosts` in [values.yaml](values.yaml) for a breaking change in the `path` parameter
+
 ## 0.3.17
 
 * Fix: Remove the value for bucket of `Yandex S3`, it enabled the output by default

--- a/falcosidekick/Chart.yaml
+++ b/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.24.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.3.17
+version: 0.4.0
 keywords:
   - monitoring
   - security

--- a/falcosidekick/templates/_helpers.tpl
+++ b/falcosidekick/templates/_helpers.tpl
@@ -30,3 +30,30 @@ Create chart name and version as used by the chart label.
 {{- define "falcosidekick.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "falcosidekick.ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return if ingress is stable.
+*/}}
+{{- define "falcosidekick.ingress.isStable" -}}
+  {{- eq (include "falcosidekick.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{/*
+Return if ingress supports pathType.
+*/}}
+{{- define "falcosidekick.ingress.supportsPathType" -}}
+  {{- or (eq (include "falcosidekick.ingress.isStable" .) "true") (and (eq (include "falcosidekick.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}

--- a/falcosidekick/templates/ingress-ui.yaml
+++ b/falcosidekick/templates/ingress-ui.yaml
@@ -1,7 +1,9 @@
 {{- if and .Values.webui.enabled .Values.webui.ingress.enabled -}}
 {{- $fullName := include "falcosidekick.fullname" . -}}
+{{- $ingressApiIsStable := eq (include "falcosidekick.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "falcosidekick.ingress.supportsPathType" .) "true" -}}
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "falcosidekick.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}-ui
@@ -32,10 +34,20 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
-            backend:
-              serviceName: {{ $fullName }}-ui
-              servicePort: http
+        - path: {{ .path }}
+          {{- if $ingressSupportsPathType }}
+          pathType: {{ default "ImplementationSpecific" .pathType }}
+          {{- end }}
+          backend:
+            {{- if $ingressApiIsStable }}
+            service:
+              name: {{ $fullName }}-ui
+              port:
+                name: http
+            {{- else }}
+            serviceName: {{ $fullName }}-ui
+            servicePort: http
+            {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/falcosidekick/templates/ingress.yaml
+++ b/falcosidekick/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "falcosidekick.fullname" . -}}
+{{- $ingressApiIsStable := eq (include "falcosidekick.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "falcosidekick.ingress.supportsPathType" .) "true" -}}
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "falcosidekick.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,10 +34,20 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+        - path: {{ .path }}
+          {{- if $ingressSupportsPathType }}
+          pathType: {{ default "ImplementationSpecific" .pathType }}
+          {{- end }}
+          backend:
+            {{- if $ingressApiIsStable }}
+            service:
+              name: {{ $fullName }}
+              port:
+                name: http
+            {{- else }}
+            serviceName: {{ $fullName }}
+            servicePort: http
+            {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/falcosidekick/values.yaml
+++ b/falcosidekick/values.yaml
@@ -314,7 +314,10 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: falcosidekick.local
-      paths: []
+      paths:
+        - path: /
+          # -- pathType (e.g. ImplementationSpecific, Prefix, .. etc.)
+          # pathType: Prefix
 
   tls: []
   #  - secretName: chart-example-tls
@@ -394,7 +397,16 @@ webui:
       # kubernetes.io/tls-acme: "true"
     hosts:
       - host: falcosidekick-ui.local
-        paths: ["/ui", "/events", "/healthz", "/ws"]
+        paths:
+        - path: /ui
+          # -- pathType (e.g. ImplementationSpecific, Prefix, .. etc.)
+          # pathType: Prefix
+        - path: /events
+          # pathType: Prefix
+        - path: /healthz
+          # pathType: Prefix
+        - path: /ws
+          # pathType: Prefix
 
     tls: []
     #  - secretName: chart-example-tls


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area falco-chart

> /area falco-exporter-chart

/area falcosidekick-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #273

**Special notes for your reviewer**:

```
$ helm version
version.BuildInfo{Version:"v3.6.3", GitCommit:"d506314abfb5d21419df8c7e7e68012379db2354", GitTreeState:"clean", GoVersion:"go1.16.5"}
```

Kubernetes <= 1.17:
```
$ helm template --namespace falcosidekick --name-template falcosidekick -s templates/ingress.yaml -s templates/ingress-ui.yaml --set ingress.enabled=true --set ingress.hosts[0].host=sidekick.falco.org --set ingress.hosts[0].paths[0].path=/ --set webui.enabled=true --set webui.ingress.enabled=true --kube-version 1.17 .
---
# Source: falcosidekick/templates/ingress.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: falcosidekick
  namespace: falcosidekick
  labels:
    app.kubernetes.io/name: falcosidekick
    helm.sh/chart: falcosidekick-0.3.17
    app.kubernetes.io/instance: falcosidekick
    app.kubernetes.io/managed-by: Helm
spec:
  rules:
    - host: "sidekick.falco.org"
      http:
        paths:
        - path: /
          backend:
            serviceName: falcosidekick
            servicePort: http
---
# Source: falcosidekick/templates/ingress-ui.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: falcosidekick-ui
  namespace: falcosidekick
  labels:
    app.kubernetes.io/name: falcosidekick-ui
    helm.sh/chart: falcosidekick-0.3.17
    app.kubernetes.io/instance: falcosidekick-ui
    app.kubernetes.io/managed-by: Helm
spec:
  rules:
    - host: "falcosidekick-ui.local"
      http:
        paths:
        - path: /ui
          backend:
            serviceName: falcosidekick-ui
            servicePort: http
        - path: /events
          backend:
            serviceName: falcosidekick-ui
            servicePort: http
        - path: /healthz
          backend:
            serviceName: falcosidekick-ui
            servicePort: http
        - path: /ws
          backend:
            serviceName: falcosidekick-ui
            servicePort: http
```

Kubernetes 1.18 (supports pathType with an implicit default, from 1.19 the pathType field in mandatory):
```
$ helm template --namespace falcosidekick --name-template falcosidekick -s templates/ingress.yaml -s templates/ingress-ui.yaml --set ingress.enabled=true --set ingress.hosts[0].host=sidekick.falco.org --set ingress.hosts[0].paths[0].path=/ --set webui.enabled=true --set webui.ingress.enabled=true --kube-version 1.18 .
---
# Source: falcosidekick/templates/ingress.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: falcosidekick
  namespace: falcosidekick
  labels:
    app.kubernetes.io/name: falcosidekick
    helm.sh/chart: falcosidekick-0.3.17
    app.kubernetes.io/instance: falcosidekick
    app.kubernetes.io/managed-by: Helm
spec:
  rules:
    - host: "sidekick.falco.org"
      http:
        paths:
        - path: /
          pathType: ImplementationSpecific
          backend:
            serviceName: falcosidekick
            servicePort: http
---
# Source: falcosidekick/templates/ingress-ui.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: falcosidekick-ui
  namespace: falcosidekick
  labels:
    app.kubernetes.io/name: falcosidekick-ui
    helm.sh/chart: falcosidekick-0.3.17
    app.kubernetes.io/instance: falcosidekick-ui
    app.kubernetes.io/managed-by: Helm
spec:
  rules:
    - host: "falcosidekick-ui.local"
      http:
        paths:
        - path: /ui
          pathType: ImplementationSpecific
          backend:
            serviceName: falcosidekick-ui
            servicePort: http
        - path: /events
          pathType: ImplementationSpecific
          backend:
            serviceName: falcosidekick-ui
            servicePort: http
        - path: /healthz
          pathType: ImplementationSpecific
          backend:
            serviceName: falcosidekick-ui
            servicePort: http
        - path: /ws
          pathType: ImplementationSpecific
          backend:
            serviceName: falcosidekick-ui
            servicePort: http
```

Kubernetes 1.19+:
```
$ helm template --namespace falcosidekick --name-template falcosidekick -s templates/ingress.yaml -s templates/ingress-ui.yaml --set ingress.enabled=true --set ingress.hosts[0].host=sidekick.falco.org --set ingress.hosts[0].paths[0].path=/ --set webui.enabled=true --set webui.ingress.enabled=true --kube-version 1.19 .
---
# Source: falcosidekick/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: falcosidekick
  namespace: falcosidekick
  labels:
    app.kubernetes.io/name: falcosidekick
    helm.sh/chart: falcosidekick-0.3.17
    app.kubernetes.io/instance: falcosidekick
    app.kubernetes.io/managed-by: Helm
spec:
  rules:
    - host: "sidekick.falco.org"
      http:
        paths:
        - path: /
          pathType: ImplementationSpecific
          backend:
            service:
              name: falcosidekick
              port:
                name: http
---
# Source: falcosidekick/templates/ingress-ui.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: falcosidekick-ui
  namespace: falcosidekick
  labels:
    app.kubernetes.io/name: falcosidekick-ui
    helm.sh/chart: falcosidekick-0.3.17
    app.kubernetes.io/instance: falcosidekick-ui
    app.kubernetes.io/managed-by: Helm
spec:
  rules:
    - host: "falcosidekick-ui.local"
      http:
        paths:
        - path: /ui
          pathType: ImplementationSpecific
          backend:
            service:
              name: falcosidekick-ui
              port:
                name: http
        - path: /events
          pathType: ImplementationSpecific
          backend:
            service:
              name: falcosidekick-ui
              port:
                name: http
        - path: /healthz
          pathType: ImplementationSpecific
          backend:
            service:
              name: falcosidekick-ui
              port:
                name: http
        - path: /ws
          pathType: ImplementationSpecific
          backend:
            service:
              name: falcosidekick-ui
              port:
                name: http
```

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
