### PR TITLE
Remove duplicate Fission keys in secret

### DIFF
--- a/falcosidekick/CHANGELOG.md
+++ b/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.4.1
+
+* Removes duplicate `Fission` keys from secret
+
 ## 0.4.0
 
 ### Major Changes

--- a/falcosidekick/Chart.yaml
+++ b/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.24.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.4.0
+version: 0.4.1
 keywords:
   - monitoring
   - security

--- a/falcosidekick/templates/secrets.yaml
+++ b/falcosidekick/templates/secrets.yaml
@@ -262,15 +262,6 @@ data:
   KAFKAREST_MUTUALTLS : "{{ .Values.config.kafkarest.mutualtls | printf "%t" | b64enc}}"
   KAFKAREST_CHECKCERT : "{{ .Values.config.kafkarest.checkcert | printf "%t" | b64enc}}"
 
-  # Fission Output
-  FISSION_FUNCTION: "{{ .Values.config.fission.function | b64enc }}"
-  FISSION_ROUTERNAMESPACE: "{{ .Values.config.fission.routernamespace | b64enc }}"
-  FISSION_ROUTERSERVICE: "{{ .Values.config.fission.routerservice | toString | b64enc }}"
-  FISSION_ROUTERPORT: "{{ .Values.config.fission.routerport | toString | b64enc }}"
-  FISSION_MINIMUMPRIORITY: "{{ .Values.config.fission.minimumpriority | b64enc }}"
-  FISSION_MUTUALTLS: "{{ .Values.config.fission.mutualtls | printf "%t" | b64enc }}"
-  FISSION_CHECKCERT: "{{ .Values.config.fission.checkcert | printf "%t" | b64enc }}"
-
   # WebUI Output
   {{- if .Values.webui.enabled -}}
   {{ $weburl := printf "http://%s-ui:2802" (include "falcosidekick.fullname" .) }}


### PR DESCRIPTION
Signed-off-by: Chase Martin <8998243+chasestech@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falcosidekick-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

When installing/upgrading the falcosidekick Helm chart, an error is thrown due to duplicated `FISSION_*` keys in the secrets.yaml file. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
