### PR TITLE
fix(falco): correctly escape FALCO_K8S_NODE_NAME

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.16.1
+
+* Fixed string escaping for `--k8s-node`
+
 ## v1.16.0
 
 * Upgrade to Falco 0.30.0 (see the [Falco changelog](https://github.com/falcosecurity/falco/blob/0.30.0/CHANGELOG.md))

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 1.16.0
+version: 1.16.1
 appVersion: 0.30.0
 description: Falco
 keywords:

--- a/falco/templates/daemonset.yaml
+++ b/falco/templates/daemonset.yaml
@@ -70,7 +70,7 @@ spec:
             - -k
             - {{ .Values.kubernetesSupport.apiUrl }}
             {{- if .Values.kubernetesSupport.enableNodeFilter }}
-            - --k8s-node="${FALCO_K8S_NODE_NAME}"
+            - --k8s-node="$(FALCO_K8S_NODE_NAME)"
             {{- end }}
             {{- end }}
             - -pk


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:
This fixes the escaping for the `FALCO_K8S_NODE_NAME` value, which passed a broken node name when using the `--k8s-node` cli parameter. This has been reported here 👉🏼  https://github.com/falcosecurity/falco/issues/1786

The version has been bumped to `1.16.1` to reflect the new change.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
