### PR TITLE
Fix duplicate namespace keys in role/rolebinding

### DIFF
--- a/falco-exporter/Chart.yaml
+++ b/falco-exporter/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.6.2
+version: 0.6.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/falco-exporter/templates/role.yaml
+++ b/falco-exporter/templates/role.yaml
@@ -10,7 +10,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
     - policy

--- a/falco-exporter/templates/rolebinding.yaml
+++ b/falco-exporter/templates/rolebinding.yaml
@@ -10,7 +10,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "falco-exporter.serviceAccountName" . }}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area falco-chart

/area falco-exporter-chart

> /area falcosidekick-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The `namespace` key was specified twice in the role/rolebindings which are created if PSPs are enabled. This means that the chart couldn't be applied by flux with an error like this:

```
✗ HelmRelease reconciliation failed: Helm upgrade failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 15: mapping key "namespace" already defined at line 6
```

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Chart Version bumped
