### PR TITLE
Update falcosidekick dependency

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.16.4
+
+* Bump falcosidekick chart dependency
+
 ## v1.16.2
 
 * Add `serviceAccount.annotations` configuration

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 1.16.3
+version: 1.16.4
 appVersion: 0.30.0
 description: Falco
 keywords:
@@ -19,6 +19,6 @@ maintainers:
     email: cncf-falco-dev@lists.cncf.io
 dependencies:
   - name: falcosidekick
-    version: "0.3.13"
+    version: "0.4.4"
     condition: falcosidekick.enabled
     repository: https://falcosecurity.github.io/charts


### PR DESCRIPTION
**What type of PR is this?**

/kind chart-release
/area falco-chart
/area falcosidekick-chart

**What this PR does / why we need it**:

Use the latest version of the falcosidekick chart when deploying it with falco. It is needed for newer kubernetes clusters (> 1.18) for example

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
