### PR TITLE
use ubuntu 2004 image and make explicity the resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
             shellcheck -x tests/e2e-kind.sh
             shellcheck -x .circleci/install_tools.sh
             shellcheck -x .circleci/release.sh
+
   lint-charts:
     docker:
       - image: quay.io/helmpack/chart-testing:latest
@@ -18,13 +19,17 @@ jobs:
       - run:
           name: lint
           command: ct lint --config tests/ct.yaml
+
   install-charts:
-    machine: true
+    machine:
+      image: ubuntu-2004:202111-02
+    resource_class: medium
     steps:
       - checkout
       - run:
           command: tests/e2e-kind.sh
           no_output_timeout: 1h
+
   release-charts:
     docker:
       - image: cimg/base:stable


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

- use ubuntu 2004 image and make explicity the resource class
the old ubuntu images will be deprecated https://circleci.com/blog/ubuntu-14-16-image-deprecation/

and circleci recommend to set the image when using a machine https://circleci.com/docs/2.0/configuration-reference/#available-machine-images


/assign @leogr 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #312 

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] CHANGELOG.md updated
