### PR TITLE
Make falco.httpOutput.url always take precedence. Fixes #280

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.17.5
+
+* Changed `falco.httpOutput.url` so that it always overrides the default URL, even when falcosidekick is enabled.
+
 ## v1.17.4
 
 * Upgrade to Falco 0.31.1 (see the [Falco changelog](https://github.com/falcosecurity/falco/blob/0.31.1/CHANGELOG.md))
@@ -25,7 +29,7 @@ numbering uses [semantic versioning](http://semver.org).
 * Upgrade to Falco 0.31.0 (see the [Falco changelog](https://github.com/falcosecurity/falco/blob/0.31.0/CHANGELOG.md))
 * Update rulesets from Falco 0.31.0
 * Update several configuration options under the `falco` node to reflect the new Falco version
-* Inital plugins support
+* Initial plugins support
 
 ## v1.16.4
 
@@ -241,7 +245,7 @@ numbering uses [semantic versioning](http://semver.org).
 ### Minor Changes
 
 * Allow adding InitContainers to Falco pod with `extraInitContainers` configuration
-   
+
 ## v1.3.0
 
 ### Minor Changes
@@ -259,7 +263,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 ### Minor Changes
 
-* Allow configuration using values for `imagePullSecrets` setting 
+* Allow configuration using values for `imagePullSecrets` setting
 * Add `docker.io/falcosecurity/falco` image to `falco_privileged_images` macro
 
 ## v1.2.1
@@ -298,7 +302,7 @@ numbering uses [semantic versioning](http://semver.org).
 ### Minor Changes
 
 * Upgrade to Falco 0.23.0
-* Correct socket path for `--cri` flag 
+* Correct socket path for `--cri` flag
 * Always mount `/etc` (required by `falco-driver-loader`)
 
 ## v1.1.7

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 1.17.4
+version: 1.17.5
 appVersion: 0.31.1
 description: Falco
 keywords:

--- a/falco/README.md
+++ b/falco/README.md
@@ -132,7 +132,7 @@ The following table lists the configurable parameters of the Falco chart and the
 | `falco.programOutput.keepAlive`            | Start the program once or re-spawn when a notification arrives                                                                                                                                             | `false`                                                                                                                 |
 | `falco.programOutput.program`              | Command to execute for program output                                                                                                                                                                      | `mail -s "Falco Notification" someone@example.com`                                                                      |
 | `falco.httpOutput.enabled`                 | Enable http output for security notifications                                                                                                                                                              | `false`                                                                                                                 |
-| `falco.httpOutput.url`                     | Url to notify using the http output when a notification arrives                                                                                                                                            | `http://some.url`                                                                                                       |
+| `falco.httpOutput.url`                     | Url to notify using the http output when a notification arrives                                                                                                                                            |                                                                                                                         |
 | `falco.grpc.enabled`                       | Enable the Falco gRPC server                                                                                                                                                                               | `false`                                                                                                                 |
 | `falco.grpc.threadiness`                   | Number of threads (and context) the gRPC server will use, `0` by default, which means "auto"                                                                                                               | `0`                                                                                                                     |
 | `falco.grpc.unixSocketPath`                | Unix socket the gRPC server will create                                                                                                                                                                    | `unix:///var/run/falco/falco.sock`                                                                                      |
@@ -358,7 +358,7 @@ Create a YAML file `values.yaml` as following:
 image:
   repository: falcosecurity/falco-no-driver
 
-extraInitContainers: 
+extraInitContainers:
   - name: driver-loader
     image: docker.io/falcosecurity/falco-driver-loader:latest
     imagePullPolicy: Always
@@ -442,7 +442,7 @@ helm install falco -f values.yaml falcosecurity/falco
 
 The Falco gRPC server and the Falco gRPC Outputs APIs are not enabled by default.
 Moreover, Falco supports running a gRPC server with two main binding types:
-- Over a local **Unix socket** with no authentication 
+- Over a local **Unix socket** with no authentication
 - Over the **network** with mandatory mutual TLS authentication (mTLS)
 
 > **Tip**: Once gRPC is enabled, you can deploy [falco-exporter](https://github.com/falcosecurity/falco-exporter) to export metrics to Prometheus.
@@ -462,7 +462,7 @@ helm install falco \
 
 ### gRPC over network
 
-The gRPC server over the network can only be used with mutual authentication between the clients and the server using TLS certificates. 
+The gRPC server over the network can only be used with mutual authentication between the clients and the server using TLS certificates.
 How to generate the certificates is [documented here](https://falco.org/docs/grpc/#generate-valid-ca).
 
 To install Falco with gRPC enabled over the **network**, you have to:

--- a/falco/templates/configmap.yaml
+++ b/falco/templates/configmap.yaml
@@ -218,7 +218,8 @@ data:
 
     http_output:
       enabled: {{ if .Values.falcosidekick.enabled }}true{{ else }}{{ .Values.falco.httpOutput.enabled }}{{ end }}
-      url: {{ if .Values.falcosidekick.enabled }}http://{{ template "falco.fullname" . }}-falcosidekick{{ if .Values.falcosidekick.fullfqdn }}.{{ .Release.Namespace }}.svc.cluster.local{{ end }}:{{ .Values.falcosidekick.listenport | default "2801" }}{{ else }}{{ .Values.falco.httpOutput.url }}{{ end }}
+      url: |
+        {{ if .Values.falco.httpOutput.url }}{{ .Values.falco.httpOutput.url }}{{ else }}http://{{ template "falco.fullname" . }}-falcosidekick{{ if .Values.falcosidekick.fullfqdn }}.{{ .Release.Namespace }}.svc.cluster.local{{ end }}:{{ .Values.falcosidekick.listenport | default "2801" }}{{ end }}
       user_agent: {{ .Values.falco.httpOutput.userAgent }}
 
 
@@ -260,7 +261,7 @@ data:
     # Make sure to have a consumer for them or leave this disabled.
     grpc_output:
       enabled: {{ .Values.falco.grpcOutput.enabled }}
-    
+
     # Container orchestrator metadata fetching params
     metadata_download:
       max_mb: {{ .Values.falco.metadataDownload.maxMb }}

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -351,7 +351,9 @@ falco:
 
   httpOutput:
     enabled: false
-    url: http://some.url
+    # When set, this will override an auto-generated URL which matches the falcosidekick Service.
+    # When including Falco inside a parent helm chart, you must set this since the auto-generated URL won't match (#280).
+    url: ""
     userAgent: "falcosecurity/falco"
 
   # Falco supports running a gRPC server with two main binding types


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area falco-chart
/area falcosidekick-chart

**What this PR does / why we need it**:

When including the Falco helm chart inside a parent chart, that messes with the way the falcosidekick Service name gets generated, which in turn means falco can't send notifications. A user might expect that they could override this behavior by setting `falco.httpOutput.url` but currently that value is ignored if falcosidekick is enabled.

This PR fixes that issue by always allowing `falco.httpOutput.url` to override the auto-generated URL.

**Which issue(s) this PR fixes**:

Fixes #280

**Special notes for your reviewer**:

Quick way to test:

```
$ cd falco/
$ helm template . --set falcosidekick.enabled=true | grep -A 3 "http_output"
    http_output:
      enabled: true
      url: |
        http://RELEASE-NAME-falco-falcosidekick:2801

$ helm template . --set falcosidekick.enabled=true --set falco.httpOutput.url=http://customurl | grep -A 3 "http_output"
    http_output:
      enabled: true
      url: |
        http://customurl
```

**Checklist**

- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
