### PR TITLE
Fix whitespace around http_output url

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,9 +3,13 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.17.6
+
+Remove whitespace around `falco.httpOutput.url` to fix the error `libcurl error: URL using bad/illegal format or missing URL`.
+
 ## v1.17.5
 
-* Changed `falco.httpOutput.url` so that it always overrides the default URL, even when falcosidekick is enabled.
+* Changed `falco.httpOutput.url` so that it always overrides the default URL, even when falcosidekick is enabled. (NOTE: don't use this version, see v1.17.6)
 
 ## v1.17.4
 

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 1.17.5
+version: 1.17.6
 appVersion: 0.31.1
 description: Falco
 keywords:

--- a/falco/templates/configmap.yaml
+++ b/falco/templates/configmap.yaml
@@ -218,8 +218,7 @@ data:
 
     http_output:
       enabled: {{ if .Values.falcosidekick.enabled }}true{{ else }}{{ .Values.falco.httpOutput.enabled }}{{ end }}
-      url: |
-        {{ if .Values.falco.httpOutput.url }}{{ .Values.falco.httpOutput.url }}{{ else }}http://{{ template "falco.fullname" . }}-falcosidekick{{ if .Values.falcosidekick.fullfqdn }}.{{ .Release.Namespace }}.svc.cluster.local{{ end }}:{{ .Values.falcosidekick.listenport | default "2801" }}{{ end }}
+      url: '{{ if .Values.falco.httpOutput.url }}{{ .Values.falco.httpOutput.url }}{{ else }}http://{{ template "falco.fullname" . }}-falcosidekick{{ if .Values.falcosidekick.fullfqdn }}.{{ .Release.Namespace }}.svc.cluster.local{{ end }}:{{ .Values.falcosidekick.listenport | default "2801" }}{{ end }}'
       user_agent: {{ .Values.falco.httpOutput.userAgent }}
 
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

In #320, I used the yaml pipe operator to have a multi-line string, but that preserves a trailing newline which seemed to be messing up falco. This PR fixes that by using single quotes (no newlines).

**Special notes for your reviewer**:

Test:

```
$ helm template . --set falcosidekick.enabled=true --set falco.httpOutput.url=http://customurl | grep -A 3 "http_output"
    http_output:
      enabled: true
      url: 'http://customurl'
      user_agent: falcosecurity/falco

$ helm template . --set falcosidekick.enabled=true | grep -A 3 "http_output"
    http_output:
      enabled: true
      url: 'http://RELEASE-NAME-falco-falcosidekick:2801'
      user_agent: falcosecurity/falco
```

**Checklist**
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
