### PR TITLE
adds policyreport adapter helm config for falcosidekick

### DIFF
--- a/falcosidekick/CHANGELOG.md
+++ b/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.4.6
+
+* Adds policy report adapter for falcosidekick
+
 ## 0.4.5
 
 * Allow additional service-ui annotations

--- a/falcosidekick/Chart.yaml
+++ b/falcosidekick/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-appVersion: 2.24.0
+appVersion: 2.25.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.4.5
+version: 0.4.6
 keywords:
   - monitoring
   - security

--- a/falcosidekick/README.md
+++ b/falcosidekick/README.md
@@ -328,7 +328,14 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | `config.kafkarest.version` | Kafka Rest Proxy API version 2|1 | `2`
 | `config.kafkarest.minimumpriority` | minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug |
 | `config.kafkarest.checkcert` | check if ssl certificate of the output is valid | `true`
-| `config.kafkarest.mutualtls` | if true, checkcert flag will be ignored (server cert will always be checked) | `false`
+| `config.kafkarest.mutualtls` | if true, checkcert flag will be ignored (server cert will always be checked) | `false` |
+| config.policyreport.enabled | if true; policyreport output is enabled | `false` |  |
+| config.policyreport.kubeconfig | Kubeconfig file to use (only if falcosidekick is running outside the cluster) | `"~/.kube/config"` |  |
+| config.policyreport.maxevents | the max number of events that can be in a policyreport | `1000` |  |
+| config.policyreport.minimumpriority | events with a priority above this are mapped to fail in PolicyReport Summary and lower that those are mapped to warn | `"debug"` |  |
+| config.policyreport.prunebypriority | if true; the events with lowest severity are pruned first, in FIFO order | `false` |  |
+| config.rabbitmq.minimumpriority | string | `"debug"` |  |
+| config.rabbitmq.queue | string | `""` |  |
 | `image.registry`                                 | The image registry to pull from                                                                  | `docker.io`                        |
 | `image.repository`                               | The image repository to pull from                                                                | `falcosecurity/falcosidekick`     |
 | `image.tag`                                      | The image tag to pull                                                                            | `2.23.1`                            |

--- a/falcosidekick/templates/secrets.yaml
+++ b/falcosidekick/templates/secrets.yaml
@@ -262,6 +262,13 @@ data:
   KAFKAREST_MUTUALTLS : "{{ .Values.config.kafkarest.mutualtls | printf "%t" | b64enc}}"
   KAFKAREST_CHECKCERT : "{{ .Values.config.kafkarest.checkcert | printf "%t" | b64enc}}"
 
+  # PolicyReport Ouptut
+  POLICYREPORT_ENABLED: "{{ .Values.config.policyreport.enabled | toString | b64enc}}"
+  POLICYREPORT_KUBECONFIG: "{{ .Values.config.policyreport.kubeconfig | b64enc}}"
+  POLICYREPORT_MINIMUMPRIORITY: "{{ .Values.config.policyreport.minimumpriority | b64enc}}"
+  POLICYREPORT_MAXEVENTS: "{{ .Values.config.policyreport.maxevents | toString |b64enc}}"
+  POLICYREPORT_PRUNEBYPRIORITY: "{{ .Values.config.policyreport.prunebypriority | toString | b64enc}}"
+
   # WebUI Output
   {{- if .Values.webui.enabled -}}
   {{ $weburl := printf "http://%s-ui:2802" (include "falcosidekick.fullname" .) }}

--- a/falcosidekick/values.yaml
+++ b/falcosidekick/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 2
 image:
   registry: docker.io
   repository: falcosecurity/falcosidekick
-  tag: 2.24.0
+  tag: 2.25.0
   pullPolicy: IfNotPresent
 
 podSecurityContext:
@@ -302,6 +302,14 @@ config:
     minimumpriority: ""  # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
     mutualtls: false  # if true, checkcert flag will be ignored (server cert will always be checked)
     checkcert: true  # check if ssl certificate of the output is valid (default: true)
+
+  policyreport:
+    enabled: false  # if true; policyreport output is enabled
+    kubeconfig: "~/.kube/config"  # Kubeconfig file to use (only if falcosidekick is running outside the cluster)
+    minimumpriority: "debug"  # events with a priority above this are mapped to fail in PolicyReport Summary and lower that those are mapped to warn (default="")
+    maxevents: 1000  # the max number of events that can be in a policyreport (default: 1000)
+    prunebypriority: false  # if true; the events with lowest severity are pruned first, in FIFO order (default: false)
+
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Signed-off-by: Mritunjay Sharma <mritunjaysharma394@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area falco-chart

> /area falco-exporter-chart

/area falcosidekick-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds support for policy report adapter in falcosidekick which was made available in its latest release.
Link to PR that added support is https://github.com/falcosecurity/falcosidekick/pull/256
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
