### PR TITLE
feat(falco): Add ability to specify extra env to driver loader initContainer

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.0.3
+
+* Add ability to specify extra environment variables to driver loader initContainer
+
 ## v2.0.2
 
 update(falco/OWNERS): move inactive approvers to emeritus_approvers

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.0.2
+version: 2.0.3
 appVersion: 0.32.1
 description: Falco
 keywords:

--- a/falco/generated/helm-values.md
+++ b/falco/generated/helm-values.md
@@ -1,5 +1,5 @@
 # Configuration values for falco chart
-`Chart version: v2.0.0`
+`Chart version: v2.0.3`
 ## Values
 
 | Key | Type | Default | Description |
@@ -32,9 +32,10 @@
 | driver.ebpf.path | string | `nil` | Path where the eBPF probe is located. It comes handy when the probe have been installed in the nodes using tools other than the init container deployed with the chart. |
 | driver.enabled | bool | `true` | Set it to false if you want to deploy Falco without the drivers. Always set it to false when using Falco with plugins. |
 | driver.kind | string | `"module"` | Tell Falco which driver to use. Available options: module (kernel driver) and ebpf (eBPF probe). |
-| driver.loader | object | `{"enabled":true,"initContainer":{"enabled":true,"image":{"pullPolicy":"IfNotPresent","registry":"docker.io","repository":"falcosecurity/falco-driver-loader","tag":""}}}` | Configuration for the Falco init container. |
+| driver.loader | object | `{"enabled":true,"initContainer":{"enabled":true,"env":{},"image":{"pullPolicy":"IfNotPresent","registry":"docker.io","repository":"falcosecurity/falco-driver-loader","tag":""}}}` | Configuration for the Falco init container. |
 | driver.loader.enabled | bool | `true` | Enable/disable the init container. |
 | driver.loader.initContainer.enabled | bool | `true` | Enable/disable the init container. |
+| driver.loader.initContainer.env | object | `{}` | Extra environment variables that will be pass onto Falco driver loader init container. |
 | driver.loader.initContainer.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy. |
 | driver.loader.initContainer.image.registry | string | `"docker.io"` | The image registry to pull from. |
 | driver.loader.initContainer.image.repository | string | `"falcosecurity/falco-driver-loader"` | The image repository to pull from. |

--- a/falco/templates/pod-template.tpl
+++ b/falco/templates/pod-template.tpl
@@ -295,6 +295,10 @@ spec:
     - name: FALCO_BPF_PROBE
       value: {{ .Values.driver.ebpf.path }}
   {{- end }}
+  {{- range $key, $value := .Values.driver.loader.initContainer.env }}
+    - name: "{{ $key }}"
+      value: "{{ $value }}"
+  {{- end }}
 {{- end -}}
 
 {{- define "falco.securityContext" -}}

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -192,6 +192,8 @@ driver:
         repository: falcosecurity/falco-driver-loader
         #  -- Overrides the image tag whose default is the chart appVersion.
         tag: ""
+      # -- Extra environment variables that will be pass onto Falco driver loader init container.
+      env: {}
 
 # Collectors for data enrichment (scenario requirement)
 collectors:


### PR DESCRIPTION
Signed-off-by: Tsubasa Nagasawa <toversus2357@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature
/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area falco-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

We would like to add extra environment variables (e.g. HTTP/HTTPS proxy env) to driver loader.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
