### PR TITLE
update(OWNERS): move inactive approvers to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,18 +1,12 @@
 approvers:
-  - leodido
-  - fntlnz
-  - kris-nova
   - leogr
-  - nibalizer
   - Issif
   - cpanato
 reviewers:
+  - nestorsalceda
+  - bencer
+emeritus_approvers:
   - leodido
   - fntlnz
   - kris-nova
-  - leogr
   - nibalizer
-  - nestorsalceda
-  - bencer
-  - Issif
-  - cpanato


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

For https://github.com/falcosecurity/falco/issues/2115, this PR proposes moving inactive approvers (who had very little or zero contributions over the past 6 months) from `approvers` to `emeritus_approvers` in OWNERS.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This is part of https://github.com/falcosecurity/charts/pull/360, that was split due to the required chart version bump.