### PR TITLE
update(falco/OWNERS): move inactive approvers to emeritus_approvers

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,12 +3,17 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.0.2
+
+update(falco/OWNERS): move inactive approvers to emeritus_approvers
+
 ## v2.0.1
 
 * Add description for configuration variable in values.yaml
 * Add linting target in Makefile
 * Remove configuration values table from README.md
 * Fix section titles in README.md
+
 ## v2.0.0
 
 **Note**

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.0.1
+version: 2.0.2
 appVersion: 0.32.1
 description: Falco
 keywords:

--- a/falco/OWNERS
+++ b/falco/OWNERS
@@ -1,6 +1,3 @@
-approvers:
-- bencer
-- nestorsalceda
-reviewers:
-- bencer
-- nestorsalceda
+emeritus_approvers:
+  - bencer
+  - nestorsalceda


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

For https://github.com/falcosecurity/falco/issues/2115, this PR proposes moving inactive approvers (who had very little or zero contributions over the past 6 months) from `approvers` to `emeritus_approvers` in OWNERS.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This is part of https://github.com/falcosecurity/charts/pull/360, that was split due to the required chart version bump.