### PR TITLE
Added `mounts.enforceProcMount` flag

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.0.5
+
+* Mount `/proc` only when syscall data source is enabled (default). This behaviour can be overridden via `mounts.enforceProcMount` for edge cases where the `/proc` `hostPath` mount is required without having the syscall data source enabled at the same time.
+
 ## v2.0.4
 
 * Fix templating for init containers in pod-template.tpl

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.0.4
+version: 2.0.5
 appVersion: 0.32.1
 description: Falco
 keywords:

--- a/falco/templates/pod-template.tpl
+++ b/falco/templates/pod-template.tpl
@@ -124,8 +124,10 @@ spec:
       volumeMounts:
         - mountPath: /root/.falco
           name: root-falco-fs
+        {{- if or .Values.driver.enabled .Values.mounts.enforceProcMount }}
         - mountPath: /host/proc
           name: proc-fs
+        {{- end }}
         {{- if and .Values.driver.enabled (not .Values.driver.loader.initContainer.enabled) }}
           readOnly: true
         - mountPath: /host/boot
@@ -226,9 +228,11 @@ spec:
     {{- end }}
     {{- end }}
     {{- end }}
+    {{- if or .Values.driver.enabled .Values.mounts.enforceProcMount }}
     - name: proc-fs
       hostPath:
         path: /proc
+    {{- end }}
     - name: config-volume
       configMap:
         name: {{ include "falco.fullname" . }}

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -156,6 +156,8 @@ mounts:
   volumes: []
   # -- A list of volumes you want to add to the Falco pods.
   volumeMounts: []
+  # -- By default, `/proc` from the host is only mounted into the Falco pod when `driver.enabled` is set to `true`. This flag allows it to override this behaviour for edge cases where `/proc` is needed but syscall data source is not enabled at the same time (e.g. for specific plugins).
+  enforceProcMount: false
 
 # Driver settings (scenario requirement)
 driver:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind feature
/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

When Falco is deployed without the syscall data source enabled (e.g. as Deployment for K8s audit events), it still mounts `/proc` by default, which often violates security policies (e.g. PSPs). 

When `/proc` would only be mounted when it's really required, the Falco Pod would not require a separate security policy handling whenever Falco is only configured to receive K8s audit events (or events from other plugins). Therefore, I propose to only mount it, whenever `.Values.driver.enabled` is set to `true` (so basically "by default"). To override this new default behaviour, the `mounts.enforceProcMount` flag was added to override it in case there is an edge case where the `/proc` mount is required but the syscall data source is not enabled at the same time.

This PR is the follow-up of a brief discussion with @leogr and @alacuku [from Slack](https://kubernetes.slack.com/archives/CMWH3EH32/p1658476444433579).

**Checklist**

- [X] Chart Version bumped
- [X] Variables are documented in the README.md (not required in my opinion)
- [X] CHANGELOG.md updated
