### PR TITLE
update(falco): deploy falco in privileged mode when using ebpf probe

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.0.8
+
+* When using ebpf probe Falco is deployed in `privileged` mode instead of `least privileged`.
+
 ## v2.0.7
 
 * Fix templating for priorityClassName in pod-template.tpl

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.0.7
+version: 2.0.8
 appVersion: 0.32.1
 description: Falco
 keywords:

--- a/falco/generated/helm-values.md
+++ b/falco/generated/helm-values.md
@@ -1,5 +1,5 @@
 # Configuration values for falco chart
-`Chart version: v2.0.6`
+`Chart version: v2.0.8`
 ## Values
 
 | Key | Type | Default | Description |
@@ -26,9 +26,9 @@
 | controller.deployment.replicas | int | `1` | Number of replicas when installing Falco using a deployment. Change it if you really know what you are doing. For more info check the section on Plugins in the README.md file. |
 | controller.kind | string | `"daemonset"` |  |
 | customRules | object | `{}` | Third party rules enabled for Falco. More info on the dedicated section in README.md file. |
-| driver.ebpf | object | `{"hostNetwork":true,"leastPrivileged":true,"path":null}` | Configuration section for ebpf driver. |
-| driver.ebpf.hostNetwork | bool | `true` | Needed to enable eBPF JIT at runtime for performance reasons. Can be skipped if eBPF JIT is enabled from outside the container |
-| driver.ebpf.leastPrivileged | bool | `true` | Constrain Falco with capabilities instead of running a privileged container. This option is only supported with the eBPF driver and a kernel >= 5.8. Ensure the eBPF driver is enabled (i.e., setting the `driver.kind` option to `ebpf`). |
+| driver.ebpf | object | `{"hostNetwork":false,"leastPrivileged":false,"path":null}` | Configuration section for ebpf driver. |
+| driver.ebpf.hostNetwork | bool | `false` | Needed to enable eBPF JIT at runtime for performance reasons. Can be skipped if eBPF JIT is enabled from outside the container |
+| driver.ebpf.leastPrivileged | bool | `false` | Constrain Falco with capabilities instead of running a privileged container. This option is only supported with the eBPF driver and a kernel >= 5.8. Ensure the eBPF driver is enabled (i.e., setting the `driver.kind` option to `ebpf`). |
 | driver.ebpf.path | string | `nil` | Path where the eBPF probe is located. It comes handy when the probe have been installed in the nodes using tools other than the init container deployed with the chart. |
 | driver.enabled | bool | `true` | Set it to false if you want to deploy Falco without the drivers. Always set it to false when using Falco with plugins. |
 | driver.kind | string | `"module"` | Tell Falco which driver to use. Available options: module (kernel driver) and ebpf (eBPF probe). |

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -177,11 +177,11 @@ driver:
     path:
     # -- Needed to enable eBPF JIT at runtime for performance reasons.
     # Can be skipped if eBPF JIT is enabled from outside the container
-    hostNetwork: true
+    hostNetwork: false
     # -- Constrain Falco with capabilities instead of running a privileged container.
     # This option is only supported with the eBPF driver and a kernel >= 5.8.
     # Ensure the eBPF driver is enabled (i.e., setting the `driver.kind` option to `ebpf`).
-    leastPrivileged: true
+    leastPrivileged: false
   # -- Configuration for the Falco init container.
   loader:
     # -- Enable/disable the init container.


### PR DESCRIPTION
```
Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>
```
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area falco-chart

> /area falco-exporter-chart

> /area falcosidekick-chart

> /area event-generator-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The default configuration for the `ebpf probe` uses the following configuration values `.Values.driver.ebpf.hostNetwork=true` and `.Values.driver.ebpf.leastPrivileged=true`. 

`hostNetwork=true` is needed to enable the `eBPF JIT` at runtime for performance reasons. It deploys Falco in host network in order for Falco pods to have access to `/proc/sys/net/core/bpf_jit_enable` file. As far as i know, there is not such logic implemented in Falco or [`driver-loader-script`](https://github.com/falcosecurity/falco/blob/master/scripts/falco-driver-loader) that would enable the `eBPF JIT` at runtime. Hence, this PR proposes to set the default value for `hostNetwork` to false, leaving to the users the possibility to enable it.

`leastPrivileged=true`, deploys Falco following the `principle of least privilege`. It does so by using linux `capabilities` to grant only the necessary permissions needed by Falco. The `least privileged mode` needs a `kernel >= 5.8` and at the same time the `container runtime implementation` installed in the node needs to support the following linux `capabilities`:  **CAP_BPF, CAP_SYS_RESOURCE, CAP_PERFMON and CAP_SYS_PTRACE**.  Being falco deployed in least privileged mode by default when using the `ebpf probe` most of the time falco does not work properly. This PR changes the default values of `leastPrivileged=false` increasing the chances that Falco will work out of the box when deployed with the `ebpf probe`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Let me know what do you think about this changes.

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
