### PR TITLE
fix(falco): correctly point to the root context inside a local scope

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.0.9
+
+* Fix the `certs-secret.yaml` template by correctly pointing to the root context when using the helpers.
+
 ## v2.0.8
 
 * When using ebpf probe Falco is deployed in `privileged` mode instead of `least privileged`.

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.0.8
+version: 2.0.9
 appVersion: 0.32.1
 description: Falco
 keywords:

--- a/falco/generated/helm-values.md
+++ b/falco/generated/helm-values.md
@@ -1,5 +1,5 @@
 # Configuration values for falco chart
-`Chart version: v2.0.8`
+`Chart version: v2.0.9`
 ## Values
 
 | Key | Type | Default | Description |

--- a/falco/templates/certs-secret.yaml
+++ b/falco/templates/certs-secret.yaml
@@ -3,10 +3,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "falco.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "falco.fullname" $ }}
+  namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "falco.labels" . | nindent 4 }}
+    {{- include "falco.labels" $ | nindent 4 }}
 type: Opaque
 data:
   {{ $key := .server.key }}


### PR DESCRIPTION
```
Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>
```
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area falco-chart

> /area falco-exporter-chart

> /area falcosidekick-chart

> /area event-generator-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

When using the 'with' keyword to change the scope we can not access the global variables using the `.` notation. We must use the `$` variable which is always global and will point to the root context.

**Which issue(s) this PR fixes**:
#387 
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
