### PR TITLE
Fix debugfs mount when `falco-no-driver` image and ebpf driver is used

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.0.14
+
+* Fix debugfs mount when `falco-no-driver` image and ebpf driver is used
+
 ## v2.0.13
 
 * Upgrade Falco to 0.32.2
@@ -18,6 +22,7 @@ numbering uses [semantic versioning](http://semver.org).
 ## v2.0.10
 
 * Fix name of the falco certs secret.
+
 ## v2.0.9
 
 * Fix the `certs-secret.yaml` template by correctly pointing to the root context when using the helpers.

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.0.13
+version: 2.0.14
 appVersion: 0.32.2
 description: Falco
 keywords:

--- a/falco/templates/pod-template.tpl
+++ b/falco/templates/pod-template.tpl
@@ -142,11 +142,15 @@ spec:
         - mountPath: /host/etc
           name: etc-fs
           readOnly: true
-        {{- end }}  
+        {{- end }}
         {{- if and .Values.driver.enabled (eq .Values.driver.kind "module") }}
         - mountPath: /host/dev
           name: dev-fs
           readOnly: true
+        {{- end }}
+        {{- if and .Values.driver.enabled (and (eq .Values.driver.kind "ebpf") (contains "falco-no-driver" .Values.image.repository)) }}
+        - name: debugfs
+          mountPath: /sys/kernel/debug
         {{- end }}
         {{- with .Values.collectors }}
         {{- if .enabled }}
@@ -209,6 +213,11 @@ spec:
     - name: dev-fs
       hostPath:
         path: /dev
+    {{- end }}
+    {{- if and .Values.driver.enabled (and (eq .Values.driver.kind "ebpf") (contains "falco-no-driver" .Values.image.repository)) }}
+    - name: debugfs
+      hostPath:
+        path: /sys/kernel/debug
     {{- end }}
     {{- with .Values.collectors }}
     {{- if .enabled }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

The `falco-no-driver` image was unable to start when the eBPF probe was used because the Falco Pod did not have access to the host's `/sys/kernel/debug`. However, this path would be required to load the tracepoints.

**Which issue(s) this PR fixes**:

Fixes https://github.com/falcosecurity/falco/issues/2145

**Special notes for your reviewer**: CC @Andreagit97 

**Checklist**
- [X] Chart Version bumped
- [X] Variables are documented in the README.md (not required)
- [X] CHANGELOG.md updated
