### PR TITLE
feat(falco): allow passing args to the falco-driver-loader init conta…

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.0.15
+
+* Allow passing args to the `falco-driver-loader` init container
+
 ## v2.0.14
 
 * Fix debugfs mount when `falco-no-driver` image and ebpf driver is used

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.0.14
+version: 2.0.15
 appVersion: 0.32.2
 description: Falco
 keywords:

--- a/falco/templates/pod-template.tpl
+++ b/falco/templates/pod-template.tpl
@@ -283,6 +283,10 @@ spec:
 - name: {{ .Chart.Name }}-driver-loader
   image: {{ include "falco.driverLoader.image" . }}
   imagePullPolicy: {{ .Values.driver.loader.initContainer.image.pullPolicy }}
+  {{- with .Values.driver.loader.initContainer.args }}
+  args:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if eq .Values.driver.kind "module" }}
   securityContext:
     privileged: true

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -200,6 +200,7 @@ driver:
         tag: ""
       # -- Extra environment variables that will be pass onto Falco driver loader init container.
       env: {}
+      args: []
 
 # Collectors for data enrichment (scenario requirement)
 collectors:


### PR DESCRIPTION
…iner

Signed-off-by: Benjamin Maisonnas <benjamin.maisonnas@ovhcloud.com>

/kind feature
/kind chart-release
/area falco-chart

**What this PR does / why we need it**:

Allow passing args, for instance `--compile` to the falco-driver-loader image/script

**Checklist**

- [x] Chart Version bumped
- [x] Variables are documented in the README.md => not required
- [x] CHANGELOG.md updated
