### PR TITLE
feat(falco): allow setting resources and securityContext on the falco…

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.0.16
+
+* Allow setting `resources` and `securityContext` on the `falco-driver-loader` init container
+
 ## v2.0.15
 
 * Allow passing args to the `falco-driver-loader` init container

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.0.15
+version: 2.0.16
 appVersion: 0.32.2
 description: Falco
 keywords:

--- a/falco/generated/helm-values.md
+++ b/falco/generated/helm-values.md
@@ -1,7 +1,5 @@
 # Configuration values for falco chart
-
-`Chart version: v2.0.13`
-
+`Chart version: v2.0.16`
 ## Values
 
 | Key | Type | Default | Description |
@@ -34,13 +32,16 @@
 | driver.ebpf.path | string | `nil` | Path where the eBPF probe is located. It comes handy when the probe have been installed in the nodes using tools other than the init container deployed with the chart. |
 | driver.enabled | bool | `true` | Set it to false if you want to deploy Falco without the drivers. Always set it to false when using Falco with plugins. |
 | driver.kind | string | `"module"` | Tell Falco which driver to use. Available options: module (kernel driver) and ebpf (eBPF probe). |
-| driver.loader | object | `{"enabled":true,"initContainer":{"enabled":true,"env":{},"image":{"pullPolicy":"IfNotPresent","registry":"docker.io","repository":"falcosecurity/falco-driver-loader","tag":""}}}` | Configuration for the Falco init container. |
+| driver.loader | object | `{"enabled":true,"initContainer":{"args":[],"enabled":true,"env":{},"image":{"pullPolicy":"IfNotPresent","registry":"docker.io","repository":"falcosecurity/falco-driver-loader","tag":""},"resources":{},"securityContext":{}}}` | Configuration for the Falco init container. |
 | driver.loader.enabled | bool | `true` | Enable/disable the init container. |
+| driver.loader.initContainer.args | list | `[]` | Arguments to pass to the Falco driver loader init container. |
 | driver.loader.initContainer.enabled | bool | `true` | Enable/disable the init container. |
 | driver.loader.initContainer.env | object | `{}` | Extra environment variables that will be pass onto Falco driver loader init container. |
 | driver.loader.initContainer.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy. |
 | driver.loader.initContainer.image.registry | string | `"docker.io"` | The image registry to pull from. |
 | driver.loader.initContainer.image.repository | string | `"falcosecurity/falco-driver-loader"` | The image repository to pull from. |
+| driver.loader.initContainer.resources | object | `{}` | Resources requests and limits for the Falco driver loader init container. |
+| driver.loader.initContainer.securityContext | object | `{}` | Security context for the Falco driver loader init container. Overrides the default security context. If driver.mode == "module" you must at least set `privileged: true`. |
 | extra.args | list | `[]` | Extra command-line arguments. |
 | extra.env | object | `{}` | Extra environment variables that will be pass onto Falco containers. |
 | extra.initContainers | list | `[]` | Additional initContainers for Falco pods. |

--- a/falco/templates/pod-template.tpl
+++ b/falco/templates/pod-template.tpl
@@ -287,8 +287,14 @@ spec:
   args:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if eq .Values.driver.kind "module" }}
+  {{- with .Values.driver.loader.initContainer.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   securityContext:
+  {{- if .Values.driver.loader.initContainer.securityContext }}
+    {{- toYaml .Values.driver.loader.initContainer.securityContext | nindent 4 }}
+  {{- else if eq .Values.driver.kind "module" }}
     privileged: true
   {{- end }}
   volumeMounts:

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -200,7 +200,12 @@ driver:
         tag: ""
       # -- Extra environment variables that will be pass onto Falco driver loader init container.
       env: {}
+      # -- Arguments to pass to the Falco driver loader init container.
       args: []
+      # -- Resources requests and limits for the Falco driver loader init container.
+      resources: {}
+      # -- Security context for the Falco driver loader init container. Overrides the default security context. If driver.mode == "module" you must at least set `privileged: true`.
+      securityContext: {}
 
 # Collectors for data enrichment (scenario requirement)
 collectors:


### PR DESCRIPTION
…-driver-loader init container

Signed-off-by: Benjamin Maisonnas <benjamin.maisonnas@ovhcloud.com>

**What type of PR is this?**

/kind feature
/kind chart-release
/area falco-chart

**What this PR does / why we need it**:

Give more control to users on how the init container runs, helps with satisfying kubeaudit rules and overall security.

**Checklist**
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
