### PR TITLE
fix: remove `namespace` from `clusterrole` and `clusterrolebinding` metadata

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.0.17
+
+* Fix: remove `namespace` from `clusterrole` and `clusterrolebinding` metadata
+
 ## v2.0.16
 
 * Allow setting `resources` and `securityContext` on the `falco-driver-loader` init container

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.0.16
+version: 2.0.17
 appVersion: 0.32.2
 description: Falco
 keywords:

--- a/falco/templates/clusterrole.yaml
+++ b/falco/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: {{ include "rbac.apiVersion" . }}
 metadata:
   name: {{ include "falco.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
 rules:

--- a/falco/templates/clusterrolebinding.yaml
+++ b/falco/templates/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 apiVersion: {{ include "rbac.apiVersion" . }}
 metadata:
   name: {{ include "falco.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
 subjects:

--- a/falcosidekick/CHANGELOG.md
+++ b/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.5.9
+
+* Fix: remove `namespace` from `clusterrole` and `clusterrolebinding` metadata
+
 ## 0.5.8
 
 * Support `storageEnabled` for `redis` to allow ephemeral installs

--- a/falcosidekick/Chart.yaml
+++ b/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.26.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.5.8
+version: 0.5.9
 keywords:
   - monitoring
   - security

--- a/falcosidekick/templates/rbac.yaml
+++ b/falcosidekick/templates/rbac.yaml
@@ -65,7 +65,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "falcosidekick.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "falcosidekick.name" . }}
     helm.sh/chart: {{ include "falcosidekick.chart" . }}
@@ -87,7 +86,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "falcosidekick.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "falcosidekick.name" . }}
     helm.sh/chart: {{ include "falcosidekick.chart" . }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind chart-release


**Any specific area of the project related to this PR?**


/area falco-chart


/area falcosidekick-chart


**What this PR does / why we need it**:

This PR removes `namespace` definition in `ClusterRole` and `ClusterRoleBinding` metadata.

`namespace` definition gets omitted once the resources are applied, therefore after after each build and apply these resources are changed.


**Which issue(s) this PR fixes**:

None

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
