### PR TITLE
Fix default falco values and doc

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.2.1
+
+* Fixed default helm chart value `init_config` for plugin `k8saudit` in values.yaml.
+
 ## v2.2.0
 
 * Change the grpc socket path from `unix:///var/run/falco/falco.soc` to `unix:///run/falco/falco.sock`. Please note that this change is potentially a breaking change if upgrading falco from a previous version and you have external consumers of the grpc socket.

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.2.0
+version: 2.2.1
 appVersion: 0.33.0
 description: Falco
 keywords:

--- a/falco/README.md
+++ b/falco/README.md
@@ -204,7 +204,7 @@ services:
         protocol: TCP
 
 falco:
-  rulesFile:
+  rules_file:
     - /etc/falco/k8s_audit_rules.yaml
     - /etc/falco/rules.d
   plugins:
@@ -225,7 +225,7 @@ What the above configuration does is:
 * disable the collectors by setting `collectors.enabled=false`;
 * deploy the Falco using a k8s *deploment* by setting `controller.kind=deployment`;
 * makes our Falco instance reachable by the `k8s api-server` by configuring a service for it in `services`;
-* load the correct ruleset for our plugin in `falco.rulesFile`;
+* load the correct ruleset for our plugin in `falco.rules_file`;
 * configure the plugins to be loaded, in this case the `k8saudit` and `json`;
 * and finally we add our plugins in the `load_plugins` to be loaded by Falco.
 

--- a/falco/generated/helm-values.md
+++ b/falco/generated/helm-values.md
@@ -1,5 +1,5 @@
 # Configuration values for falco chart
-`Chart version: v2.2.0`
+`Chart version: v2.2.1`
 ## Values
 
 | Key | Type | Default | Description |
@@ -72,7 +72,7 @@
 | falco.output_timeout | int | `2000` | Duration in milliseconds to wait before considering the output timeout deadline exceed. |
 | falco.outputs.max_burst | int | `1000` | Maximum number of tokens outstanding. |
 | falco.outputs.rate | int | `1` | Number of tokens gained per second. |
-| falco.plugins | list | `[{"init_config":null,"library_path":"libk8saudit.so","name":"k8saudit","open_params":"http://:9765/k8s-audit"},{"library_path":"libcloudtrail.so","name":"cloudtrail"},{"init_config":"","library_path":"libjson.so","name":"json"}]` | Plugins configuration. Add here all plugins and their configuration. Please consult the plugins documentation for more info. Remember to add the plugins name in "load_plugins: []" in order to load them in Falco. |
+| falco.plugins | list | `[{"init_config":"","library_path":"libk8saudit.so","name":"k8saudit","open_params":"http://:9765/k8s-audit"},{"library_path":"libcloudtrail.so","name":"cloudtrail"},{"init_config":"","library_path":"libjson.so","name":"json"}]` | Plugins configuration. Add here all plugins and their configuration. Please consult the plugins documentation for more info. Remember to add the plugins name in "load_plugins: []" in order to load them in Falco. |
 | falco.priority | string | `"debug"` | Minimum rule priority level to load and run. All rules having a priority more severe than this level will be loaded/run.  Can be one of "emergency", "alert", "critical", "error", "warning", "notice", "informational", "debug". |
 | falco.program_output.enabled | bool | `false` | Enable program output for security notifications. |
 | falco.program_output.keep_alive | bool | `false` | Start the program once or re-spawn when a notification arrives. |

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -346,7 +346,7 @@ falco:
   plugins:
     - name: k8saudit
       library_path: libk8saudit.so
-      init_config:
+      init_config: ""
       #   maxEventSize: 262144
       #   webhookMaxBatchSize: 12582912
       #   sslCertificate: /etc/falco/falco.pem


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

/kind documentation

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falco-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

When upgrading our old helm chart (v1.19.4) to the new version of the helm chart (v2.2.0) in our environment with the new helm chart values, we ran into an issue where, upon digging into what caused the error, we found the default `init_config` for the k8saudit plugin is set to `null` instead of empty string thus falco could not start. 


**Which issue(s) this PR fixes**:

We ran into the following issue when updating our helm chart:

```
Tue Oct 25 11:15:27 2022: Runtime error: Error reading config file(/etc/falco/falco.yaml): could not load plugins config: yaml-cpp: error at line 35, column 16: bad conversion. Exiting.
```

This only happens if users do not specify any "plugins" and use the default value provided by the chart.

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

