### PR TITLE
feat: add variable namespaceOverride to falco chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ So, we ask you to follow these simple steps when making your PR:
 - The [DCO](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) is required to contribute to a `falcosecurity` project. So ensure that all your commits have been signed off. We will not be able to merge the PR if a commit is not signed off.
 - Bump the version number of the chart by modifying the `version` value in the chart's `Chart.yaml` file. This is particularly important, as it allows our CI to release a new chart version. If the version has not been increased, we will not be able to merge the PR.
 - Add a new section in the chart's `CHANGELOG.md` file with the new version number of the chart.
-- If your changes affect any chart variables, please update the chart's `README.md` file accordingly.
+- If your changes affect any chart variables, please update the chart's `README.md` file accordingly and run `make docs` in the chart folder.
 
 Finally, when opening your PR, please fill in the provided PR template, including the final checklist of items to indicate that all the steps above have been performed. 
 

--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.3.0
+
+* Add variable namespaceOverride to allow setting release namespace in values
+
 ## v2.2.0
 
 * Change the grpc socket path from `unix:///var/run/falco/falco.soc` to `unix:///run/falco/falco.sock`. Please note that this change is potentially a breaking change if upgrading falco from a previous version and you have external consumers of the grpc socket.

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.2.0
+version: 2.3.0
 appVersion: 0.33.0
 description: Falco
 keywords:

--- a/falco/generated/helm-values.md
+++ b/falco/generated/helm-values.md
@@ -1,5 +1,5 @@
 # Configuration values for falco chart
-`Chart version: v2.2.0`
+`Chart version: v2.3.0`
 ## Values
 
 | Key | Type | Default | Description |
@@ -114,6 +114,7 @@
 | mounts.volumeMounts | list | `[]` | A list of volumes you want to add to the Falco pods. |
 | mounts.volumes | list | `[]` | A list of volumes you want to add to the Falco pods. |
 | nameOverride | string | `""` | Put here the new name if you want to override the release name used for Falco components. |
+| namespaceOverride | string | `""` | Override the deployment namespace |
 | nodeSelector | object | `{}` | Selectors used to deploy Falco on a given node/nodes. |
 | podAnnotations | object | `{}` | Add additional pod annotations |
 | podLabels | object | `{}` | Add additional pod labels |

--- a/falco/templates/_helpers.tpl
+++ b/falco/templates/_helpers.tpl
@@ -31,6 +31,13 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Allow the release namespace to be overridden
+*/}}
+{{- define "falco.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "falco.labels" -}}

--- a/falco/templates/certs-secret.yaml
+++ b/falco/templates/certs-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "falco.fullname" $ }}-certs
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "falco.namespace" $ }}
   labels:
     {{- include "falco.labels" $ | nindent 4 }}
 type: Opaque

--- a/falco/templates/clusterrolebinding.yaml
+++ b/falco/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "falco.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "falco.namespace" . }}
 roleRef:
   kind: ClusterRole
   name: {{ include "falco.fullname" . }}

--- a/falco/templates/configmap.yaml
+++ b/falco/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "falco.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "falco.namespace" . }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
 data:

--- a/falco/templates/daemonset.yaml
+++ b/falco/templates/daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "falco.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "falco.namespace" . }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
 spec:

--- a/falco/templates/deployment.yaml
+++ b/falco/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "falco.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "falco.namespace" . }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
 spec:

--- a/falco/templates/grpc-service.yaml
+++ b/falco/templates/grpc-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ include "falco.fullname" . }}-grpc
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "falco.namespace" . }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
 spec:

--- a/falco/templates/rules-configmap.yaml
+++ b/falco/templates/rules-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "falco.fullname" . }}-rules
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "falco.namespace" . }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
 data:

--- a/falco/templates/securitycontextconstraints.yaml
+++ b/falco/templates/securitycontextconstraints.yaml
@@ -6,7 +6,7 @@ metadata:
     kubernetes.io/description: |
       This provides the minimum requirements Falco to run in Openshift.
   name: {{ include "falco.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "falco.namespace" . }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
 allowHostDirVolumePlugin: true
@@ -34,7 +34,7 @@ seccompProfiles:
 supplementalGroups:
   type: RunAsAny
 users:
-- system:serviceaccount:{{ .Release.Namespace }}:{{ include "falco.serviceAccountName" . }}
+- system:serviceaccount:{{ include "falco.namespace" . }}:{{ include "falco.serviceAccountName" . }}
 volumes:
 - hostPath
 - emptyDir

--- a/falco/templates/serviceaccount.yaml
+++ b/falco/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "falco.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "falco.namespace" . }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/falco/templates/services.yaml
+++ b/falco/templates/services.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "falco.fullname" $dot }}-{{ $service.name }}
+  namespace: {{ include "falco.namespace" $dot }}
   labels:
     {{- include "falco.labels" $dot | nindent 4 }}
 spec:

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -20,6 +20,8 @@ imagePullSecrets: []
 nameOverride: ""
 # -- Same as nameOverride but for the fullname.
 fullnameOverride: ""
+# -- Override the deployment namespace
+namespaceOverride: ""
 
 rbac:
   # Create and use rbac resources when set to true. Needed to fetch k8s metadata from the api-server.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

Allow completely defining falco's deployment using its values.yaml.

Contrasted with the current process, namespace is the only bit of configuration that must be stored somewhere else. Thus deploying requires `helm install falco falcosecurity/falco --values falco/values.yaml --namespace [some-other-source]`. Config being split into two sources adds a layer of complexity, especially in CICD.

**Which issue(s) this PR fixes**:

Fixes #422

**Special notes for your reviewer**:

- Testing: Does not break deployments that use the default recommend command `helm install falco falcosecurity/falco --namespace falco`
- I did not see variable documentation in README.md
- Install documentation left unchanged as `--namespace` argument remains default install method

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
