### PR TITLE
Run Falco without syscall driver as unprivileged

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.4.4
+
+* Changed Falco default behaviour to newly run as unprivileged user (`runAsUser: 1000`, `runAsNonRoot: true`) as long as Falco does not have the syscall event source enabled.
+
 ## v2.4.3
 
 * Update README for gVisor and GKE

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.4.3
+version: 2.4.4
 appVersion: 0.33.1
 description: Falco
 keywords:

--- a/falco/templates/pod-template.tpl
+++ b/falco/templates/pod-template.tpl
@@ -383,6 +383,9 @@ spec:
       {{- $securityContext := set $securityContext "privileged" true -}}
     {{- end -}}
   {{- end -}}
+{{- else -}}
+  {{- $securityContext := set $securityContext "runAsUser" 1000 -}}
+  {{- $securityContext := set $securityContext "runAsNonRoot" true -}}
 {{- end -}}
 {{- if not (empty (.Values.containerSecurityContext)) -}}
   {{-  toYaml .Values.containerSecurityContext }}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**: 

This PR changes Falco default behavior to newly run as unprivileged user (`runAsUser: 1000`, `runAsNonRoot: true`), as long as Falco does not have the syscall event source enabled. Basically, the Falco Pod will get the following `securityContext` flags if `.Values.driver.enabled` is `false`:

```yaml
  containers:
  - args:
    - /usr/bin/falco
    - --disable-source
    - syscall
...
    image: docker.io/falcosecurity/falco-no-driver:0.33.1
...
    securityContext:
      runAsNonRoot: true
      runAsUser: 1000
```

Falco still works like it should:
```
$ k logs -f falco-55b567dbc6-2mcwq
Fri Dec 16 13:57:26 2022: Falco version: 0.33.1 (aarch64)
Fri Dec 16 13:57:26 2022: Falco initialized with configuration file: /etc/falco/falco.yaml
Fri Dec 16 13:57:26 2022: Loading plugin 'k8saudit' from file /usr/share/falco/plugins/libk8saudit.so
Fri Dec 16 13:57:27 2022: Loading plugin 'json' from file /usr/share/falco/plugins/libjson.so
Fri Dec 16 13:57:27 2022: Loading rules from file /etc/falco/k8s_audit_rules.yaml
Fri Dec 16 13:57:27 2022: Starting health webserver with threadiness 2, listening on port 8765
Fri Dec 16 13:57:27 2022: Enabled event sources: k8s_audit
Fri Dec 16 13:57:27 2022: Opening capture with plugin 'k8saudit'
```

The only thing I found is that when you now `exec` into the Falco pod, you will get a bash error:
```
$ k exec -it falco-55b567dbc6-2mcwq -- /bin/bash
bash: /root/.bashrc: Permission denied
$ I have no name!@falco-55b567dbc6-2mcwq:/$ id
uid=1000 gid=0(root) groups=0(root)
```

However, this could easily be resolved with a proper creation of a `falco` user with UID `1000` in the container image.

**Which issue(s) this PR fixes**:

Fixes https://github.com/falcosecurity/charts/issues/377

**Special notes for your reviewer**:

**Checklist**
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] CHANGELOG.md updated
