### PR TITLE
fix: Only print DaemonSet info if set to DaemonSet

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.5.2
+
+* Add `controller.annotations` configuration
+
 ## v2.5.1
 
 * Update README to clarify driver behavior for chart
@@ -201,7 +205,7 @@ update(falco/OWNERS): move inactive approvers to emeritus_approvers
 ## v1.18.5
 
 * Bump falcosidekick chart dependency
-  
+
 ## v1.18.4
 
 * Now the url to falcosidekick on NOTES.txt on falco helm chart points to the right place.

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.5.1
+version: 2.5.2
 appVersion: 0.33.1
 description: Falco
 keywords:

--- a/falco/templates/NOTES.txt
+++ b/falco/templates/NOTES.txt
@@ -1,8 +1,9 @@
+{{- if eq .Values.controller.kind "daemonset" }}
 Falco agents are spinning up on each node in your cluster. After a few
 seconds, they are going to start monitoring your containers looking for
 security issues.
 {{printf "\n" }}
-
+{{- end}}
 {{- if .Values.integrations }}
 WARNING: The following integrations have been deprecated and removed
  - gcscc


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

It makes part of the NOTES only rendered if `.Values.controller.kind` is set to `daemonset`. It does not make sense to show that part of the notes if the kind os set to `deployment`.

**Which issue(s) this PR fixes**:

Fixes #448 
