### PR TITLE
fix prometheus extralabels configuration in falcosidekick

### DIFF
--- a/falcosidekick/CHANGELOG.md
+++ b/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.5.14
+
+* Fix Prometheus extralabels configuration in Falcosidekick
+
 ## 0.5.13
 
 * Fix missing quotes in Falcosidekick-UI ttl argument

--- a/falcosidekick/Chart.yaml
+++ b/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.27.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.5.13
+version: 0.5.14
 keywords:
   - monitoring
   - security

--- a/falcosidekick/templates/secrets.yaml
+++ b/falcosidekick/templates/secrets.yaml
@@ -173,7 +173,7 @@ data:
   LOKI_CHECKCERT: "{{ .Values.config.loki.checkcert | printf "%t" | b64enc }}"
 
   # Prometheus Output
-  PROMETHEUS_EXTRALABELS: "{{ .Values.config.loki.extralabels | b64enc }}"
+  PROMETHEUS_EXTRALABELS: "{{ .Values.config.prometheus.extralabels | b64enc }}"
 
   # Nats Output
   NATS_HOSTPORT: "{{ .Values.config.nats.hostport | b64enc }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area falcosidekick-chart

**What this PR does / why we need it**:

This pull request fixes an issue in falcosidekick's chart version 0.5.12. The current configuration was using the wrong key in [falcosidekick/templates/secrets.yaml](https://github.com/falcosecurity/charts/blob/9b27a5925f4c8a4d0fd500a2e963d572e2cce767/falcosidekick/templates/secrets.yaml#L176), causing the Prometheus `extralabels` to not be set correctly.

This pull request changes it to:
```yaml
 PROMETHEUS_EXTRALABELS: "{{ .Values.config.prometheus.extralabels | b64enc }}"
 ```

**Which issue(s) this PR fixes**:

Fixes #451

Coauthored by: @aaniqtejani