### PR TITLE
fix(falcosidekick): quote integer redis ttl value

### DIFF
--- a/falcosidekick/CHANGELOG.md
+++ b/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.5.13
+
+* Fix missing quotes in Falcosidekick-UI ttl argument
+
 ## 0.5.12
 
 * Fix missing space in Falcosidekick-UI ttl argument

--- a/falcosidekick/Chart.yaml
+++ b/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.27.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.5.12
+version: 0.5.13
 keywords:
   - monitoring
   - security

--- a/falcosidekick/templates/deployment-ui.yaml
+++ b/falcosidekick/templates/deployment-ui.yaml
@@ -61,7 +61,7 @@ spec:
             {{- end}}
             {{- if .Values.webui.ttl }}
             - "-t"
-            - {{ .Values.webui.ttl }}
+            - {{ .Values.webui.ttl | quote }}
             {{- end}}
             {{- if .Values.webui.loglevel }}
             - "-l"
@@ -160,21 +160,21 @@ spec:
             - name: redis
               containerPort: 6379
               protocol: TCP
-          livenessProbe: 
+          livenessProbe:
             tcpSocket:
               port: 6379
-            initialDelaySeconds: 5 
-            periodSeconds: 5 
-            timeoutSeconds: 2 
-            successThreshold: 1 
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            successThreshold: 1
             failureThreshold: 3
           readinessProbe:
             tcpSocket:
               port: 6379
-            initialDelaySeconds: 5 
-            periodSeconds: 5 
-            timeoutSeconds: 2 
-            successThreshold: 1 
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            successThreshold: 1
             failureThreshold: 3
           {{- if .Values.webui.redis.securityContext }}
           securityContext:


### PR DESCRIPTION
/kind bug

/kind chart-release

/area falcosidekick-chart

**What this PR does / why we need it**:

Adds quotes to number because numbers are not allowed to be used as container arguments.

**Which issue(s) this PR fixes**:

Fixes #454

**Special notes for your reviewer**:

**Checklist**

- [x] Chart Version bumped
- [x] CHANGELOG.md updated
