### PR TITLE
Expose Falco controller annotations

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.4.7
+
+* Add `controller.annotations` configuration
+
 ## v2.4.6
 
 * Bump `falcosidekick` dependency to 0.5.11

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.4.6
+version: 2.4.7
 appVersion: 0.33.1
 description: Falco
 keywords:

--- a/falco/templates/daemonset.yaml
+++ b/falco/templates/daemonset.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ include "falco.namespace" . }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
+  {{- if .Values.controller.annotations }}
+  annotations:
+  {{ toYaml .Values.controller.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/falco/templates/deployment.yaml
+++ b/falco/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ include "falco.namespace" . }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
+  {{- if .Values.controller.annotations }}
+  annotations:
+  {{ toYaml .Values.controller.annotations | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.controller.deployment.replicas }}
   selector:

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -137,6 +137,8 @@ tty: false
 controller:
   # Available options: deployment, daemonset.
   kind: daemonset
+  # Annotations to add to the daemonset or deployment
+  annotations: {}
   daemonset:
     updateStrategy:
       # You can also customize maxUnavailable or minReadySeconds if you


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

It exposes controller's annotations in the `values.yaml` file. This might be useful for some production environments that require specific annotations.

**Checklist**
- [ ] Variables are documented in the README.md
- [x] CHANGELOG.md updated
