### PR TITLE
Bump falcosidekick dependency to 0.5.14

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.5.3
+
+* Bump `falcosidekick` dependency to 0.5.14
+
 ## v2.5.2
 
 * Add `controller.annotations` configuration

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.5.2
+version: 2.5.3
 appVersion: 0.33.1
 description: Falco
 keywords:
@@ -19,6 +19,6 @@ maintainers:
     email: cncf-falco-dev@lists.cncf.io
 dependencies:
   - name: falcosidekick
-    version: "0.5.11"
+    version: "0.5.14"
     condition: falcosidekick.enabled
     repository: https://falcosecurity.github.io/charts


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area falco-chart

> /area falco-exporter-chart

/area falcosidekick-chart

> /area event-generator-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

Bumps falcosidekick dependency to 0.5.14 in the Falco chart.

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
