### PR TITLE
docs(falco): Fix incorrect entry in changelog

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -9,7 +9,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 ## v2.5.2
 
-* Add `controller.annotations` configuration
+* Fixed notes template to only include daemon set info if set to daemon set
 
 ## v2.5.1
 

--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.5.4
+
+* Fix incorrect entry in v2.5.2 changelog 
+
 ## v2.5.3
 
 * Bump `falcosidekick` dependency to 0.5.14

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 2.5.3
+version: 2.5.4
 appVersion: 0.33.1
 description: Falco
 keywords:


### PR DESCRIPTION
Signed-off-by: Tim Schwenke <tim@trallnag.com>

/kind documentation

/area falco-chart

The pull request https://github.com/falcosecurity/charts/pull/449 introduced an incorrect entry into the changelog.

The entries for v2.4.7 and v2.5.2 are the same, which should not be the case.

https://github.com/falcosecurity/charts/blob/a3a315caec40b145e940ed63d418c59ac8134190/falco/CHANGELOG.md?plain=1#L10-L12

https://github.com/falcosecurity/charts/blob/a3a315caec40b145e940ed63d418c59ac8134190/falco/CHANGELOG.md?plain=1#L24-L26

Related PRs:

- https://github.com/falcosecurity/charts/pull/456
- https://github.com/falcosecurity/charts/pull/449

Happened during a rebase.

Thanks to @bryanasdev000 for noticing this and bringing it up.

Fixes: #461