### PR TITLE
fix: adds app selector to pod template

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v3.1.3
+
+* Updates the grpc-service to use the correct label selector
+
 ## v3.1.2
 
 * Bump `falcosidekick` dependency to 0.6.1

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 3.1.2
+version: 3.1.3
 appVersion: 0.34.1
 description: Falco
 keywords:

--- a/falco/templates/grpc-service.yaml
+++ b/falco/templates/grpc-service.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   clusterIP: None
   selector:
-    app: {{ include "falco.fullname" . }}
+    {{- include "falco.selectorLabels" . | nindent 4 }}
   ports:
   - protocol: TCP
     port: {{ include "grpc.port" . }}


### PR DESCRIPTION

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area falco-chart

> /area falco-exporter-chart

> /area falcosidekick-chart

/area event-generator-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
The provided falco-grpc service app selector does not exist in the pod template.

**Which issue(s) this PR fixes**:
Adds a label to the the pod template so the service can route traffic to that pod.
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
There are template options to add pod selectors. However, since the falco-grpc servcie is provided in the chart and specifies a app label it seems it would be appropriate to have a matching label in the pod template.
 
**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [ ] CHANGELOG.md updated
