### PR TITLE
fix: use SYS_ADMIN and SYS_RESOURCE capabilities since SYS_PERFMON is not sufficient

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,9 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v3.1.4
+
+* Use `SYS_ADMIN` and `SYS_RESOURCE` capabilities since `SYS_PERFMON` is not sufficient
 ## v3.1.3
 
 * Updates the grpc-service to use the correct label selector

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 3.1.3
+version: 3.1.4
 appVersion: 0.34.1
 description: Falco
 keywords:

--- a/falco/templates/pod-template.tpl
+++ b/falco/templates/pod-template.tpl
@@ -394,7 +394,7 @@ spec:
   {{- end -}}
   {{- if eq .Values.driver.kind "ebpf" -}}
     {{- if .Values.driver.ebpf.leastPrivileged -}}
-      {{- $securityContext := set $securityContext "capabilities" (dict "add" (list "BPF" "SYS_RESOURCE" "PERFMON" "SYS_PTRACE")) -}}
+      {{- $securityContext := set $securityContext "capabilities" (dict "add" (list "SYS_ADMIN" "SYS_RESOURCE")) -}}
     {{- else -}}
       {{- $securityContext := set $securityContext "privileged" true -}}
     {{- end -}}


### PR DESCRIPTION
Related to falcosecurity/falco#2487

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug
/kind chart-release

**Any specific area of the project related to this PR?**
/area falco-chart


**What this PR does / why we need it**:

SYS_PERFMON capability is not sufficient to run falco with `leastPrivileged: true`, see falcosecurity/falco#2487 for details

**Which issue(s) this PR fixes**:
I am not sure if falcosecurity/falco#2487 would be fixed since I believe some investigation will be done on why this is the case with SYS_PERFMON, but this makes the chart usable with  `leastPrivileged: true`


**Checklist**
- [x ] Chart Version bumped
- [x ] CHANGELOG.md updated
