### PR TITLE
fix falco host path mount of /sys/module

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v3.1.4
+
+* Mount on `/sys/module` instead of `/sys/module/falco` for kernel module version.
+
 ## v3.1.3
 
 * Updates the grpc-service to use the correct label selector

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 3.1.3
+version: 3.1.4
 appVersion: 0.34.1
 description: Falco
 keywords:

--- a/falco/templates/pod-template.tpl
+++ b/falco/templates/pod-template.tpl
@@ -167,7 +167,7 @@ spec:
           name: dev-fs
           readOnly: true
         - name: sys-fs
-          mountPath: /sys/module/falco
+          mountPath: /sys/module
         {{- end }}
         {{- if and .Values.driver.enabled (and (eq .Values.driver.kind "ebpf") (contains "falco-no-driver" .Values.image.repository)) }}
         - name: debugfs
@@ -263,7 +263,7 @@ spec:
         path: /dev
     - name: sys-fs
       hostPath:
-        path: /sys/module/falco
+        path: /sys/module
     {{- end }}
     {{- if and .Values.driver.enabled (and (eq .Values.driver.kind "ebpf") (contains "falco-no-driver" .Values.image.repository)) }}
     - name: debugfs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

The current setting blocks my Falco 0.34.1 deployment in EKS, I manually modified the mounting path to `/sys/module` and it works.

> Uncomment one (or more) `/area <>` lines:

 /area falco-chart

> /area falco-exporter-chart

> /area falcosidekick-chart

> /area event-generator-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

Falco was mounted on directory `/sys/module/falco`, since the directory doesn't exist. Kubelet need to create the directory `falco` under `/sys/module`. However, `/sys/module` is a virtual filesystem, normal directory creation doesn't work in that directory, even with root user.  Hence, mount on `/sys/module` instead of `/sys/module/falco`.

**Special notes for your reviewer**:

The current setting blocks my falco 0.34.1 deployment in EKS. After I modified the host path mount to `/sys/module`, it works.

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
