### PR TITLE
fix(falco): use list as default for env parameter of init and follow containers

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v3.1.5
+
+* Use list as default for env parameter of init and follow containers
+
 ## v3.1.4
 
 * Fix typo in values-k8audit file

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 3.1.4
+version: 3.1.5
 appVersion: 0.34.1
 description: Falco
 keywords:

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -346,7 +346,7 @@ falcoctl:
     install:
       enabled: true
       # -- Extra environment variables that will be pass onto falcoctl-artifact-install init container.
-      env: {}
+      env: []
       # -- Arguments to pass to the falcoctl-artifact-install init container.
       args: ["--verbose"]
       # -- Resources requests and limits for the falcoctl-artifact-install init container.
@@ -361,7 +361,7 @@ falcoctl:
     follow:
       enabled: true
       # -- Extra environment variables that will be pass onto falcoctl-artifact-follow sidecar container.
-      env: {}
+      env: []
       # -- Arguments to pass to the falcoctl-artifact-follow sidecar container.
       args: ["--verbose"]
       # -- Resources requests and limits for the falcoctl-artifact-follow sidecar container.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug


> If this PR will release a new chart version please make sure to also uncomment the following line:

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falco-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The default env key of the init and follow containers expects a map, but the correct value type should be a list.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #486 

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
