### PR TITLE
Add readiness/liveness probe values to falco-exporter-chart

### DIFF
--- a/falco-exporter/CHANGELOG.md
+++ b/falco-exporter/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to `falco-exporter` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.9.4
+
+### Minor Changes
+
+* Add options to configure readiness/liveness probe values
+
 ## v0.9.3
 
 ### Minor Changes

--- a/falco-exporter/Chart.yaml
+++ b/falco-exporter/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.3
+version: 0.9.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/falco-exporter/README.md
+++ b/falco-exporter/README.md
@@ -66,7 +66,15 @@ The following table lists the main configurable parameters of the chart and thei
 | `scc.create`                                     | Create OpenShift's Security Context Constraint                                                   | `true`                             |
 | `service.mTLS.enabled`                           | Enable falco-exporter server Mutual TLS feature                                                  | `false`                            |
 | `prometheusRules.enabled`                        | Enable the creation of falco-exporter PrometheusRules                                            | `false`                            |
-| `daemonset.podLabels`                            | Customized Daemonset pod labels                                                                  | `{}`
+| `daemonset.podLabels`                            | Customized Daemonset pod labels                                                                  | `{}`                               |
+| `healthChecks.livenessProbe.probesPort`          | Liveness probes port                                                                             | `19376`                            |
+| `healthChecks.readinessProbe.probesPort`         | Readiness probes port                                                                            | `19376`                            |
+| `healthChecks.livenessProbe.initialDelaySeconds` | Number of seconds before performing the first liveness probe                                     | `60`                               |
+| `healthChecks.readinessProbe.initialDelaySeconds`| Number of seconds before performing the first readiness probe                                    | `30`                               |
+| `healthChecks.livenessProbe.timeoutSeconds`      | Number of seconds after which the liveness probe times out                                       | `5`                                |
+| `healthChecks.readinessProbe.timeoutSeconds`     | Number of seconds after which the readiness probe times out                                      | `5`                                |
+| `healthChecks.livenessProbe.periodSeconds`       | Time interval in seconds to perform the liveness probe                                           | `15`                               |
+| `healthChecks.readinessProbe.periodSeconds`      | Time interval in seconds to perform the readiness probe                                          | `15`                               |
 
 Please, refer to [values.yaml](./values.yaml) for the full list of configurable parameters.
 

--- a/falco-exporter/templates/daemonset.yaml
+++ b/falco-exporter/templates/daemonset.yaml
@@ -59,18 +59,18 @@ spec:
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           livenessProbe:
+            initialDelaySeconds: {{ .Values.healthChecks.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.healthChecks.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.healthChecks.livenessProbe.periodSeconds }}          
             httpGet:
               path: /liveness
-              initialDelaySeconds: {{ .Values.healthChecks.livenessProbe.initialDelaySeconds }}
-              timeoutSeconds: {{ .Values.healthChecks.livenessProbe.timeoutSeconds }}
-              periodSeconds: {{ .Values.healthChecks.livenessProbe.periodSeconds }}
               port: {{ .Values.healthChecks.livenessProbe.probesPort }}
           readinessProbe:
+            initialDelaySeconds: {{ .Values.healthChecks.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.healthChecks.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.healthChecks.readinessProbe.periodSeconds }}
             httpGet:
               path: /readiness
-              initialDelaySeconds: {{ .Values.healthChecks.readinessProbe.initialDelaySeconds }}
-              timeoutSeconds: {{ .Values.healthChecks.readinessProbe.timeoutSeconds }}
-              periodSeconds: {{ .Values.healthChecks.readinessProbe.periodSeconds }}
               port: {{ .Values.healthChecks.readinessProbe.probesPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/falco-exporter/templates/daemonset.yaml
+++ b/falco-exporter/templates/daemonset.yaml
@@ -61,11 +61,17 @@ spec:
           livenessProbe:
             httpGet:
               path: /liveness
-              port: {{ .Values.probesPort }}
+              initialDelaySeconds: {{ .Values.healthChecks.livenessProbe.initialDelaySeconds }}
+              timeoutSeconds: {{ .Values.healthChecks.livenessProbe.timeoutSeconds }}
+              periodSeconds: {{ .Values.healthChecks.livenessProbe.periodSeconds }}
+              port: {{ .Values.healthChecks.livenessProbe.probesPort }}
           readinessProbe:
             httpGet:
               path: /readiness
-              port: {{ .Values.probesPort }}
+              initialDelaySeconds: {{ .Values.healthChecks.readinessProbe.initialDelaySeconds }}
+              timeoutSeconds: {{ .Values.healthChecks.readinessProbe.timeoutSeconds }}
+              periodSeconds: {{ .Values.healthChecks.readinessProbe.periodSeconds }}
+              port: {{ .Values.healthChecks.readinessProbe.probesPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/falco-exporter/values.yaml
+++ b/falco-exporter/values.yaml
@@ -16,8 +16,25 @@ service:
   mTLS:
     enabled: false
 
-# /readiness and /liveness probes port
-probesPort: 19376
+healthChecks:
+  livenessProbe:
+    # liveness probes port
+    probesPort: 19376
+    # -- Tells the kubelet that it should wait X seconds before performing the first probe.
+    initialDelaySeconds: 60
+    # -- Number of seconds after which the probe times out.
+    timeoutSeconds: 5
+    # -- Specifies that the kubelet should perform the check every x seconds.
+    periodSeconds: 15
+  readinessProbe:
+    # readiness probes port
+    probesPort: 19376
+    # -- Tells the kubelet that it should wait X seconds before performing the first probe.
+    initialDelaySeconds: 30
+    # -- Number of seconds after which the probe times out.
+    timeoutSeconds: 5
+    # -- Specifies that the kubelet should perform the check every x seconds.
+    periodSeconds: 15
 
 image:
   registry: docker.io


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-exporter-chart

**What this PR does / why we need it**:
Add variables for readiness and liveness probes to configure timings such as `initialDelaySeconds`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

My first PR, hopefully I have considered everything.

**Checklist**
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
