### PR TITLE
chore: bump chart to Falco 0.35.1

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,11 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v3.3.0
+* Upgrade Falco to 0.35.1. For more info see the release notes: https://github.com/falcosecurity/falco/releases/tag/0.35.1
+* Upgrade falcoctl to 0.5.1. For more info see the release notes: https://github.com/falcosecurity/falcoctl/releases/tag/v0.5.1
+* Introduce least privileged mode in modern ebpf. For more info see: https://falco.org/docs/event-sources/kernel/#least-privileged-mode-2
+ 
 ## v3.2.1
 * Set falco.http_output.url to empty string in values.yaml file
 

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: falco
-version: 3.2.1
-appVersion: "0.35.0"
+version: 3.3.0
+appVersion: "0.35.1"
 description: Falco
 keywords:
   - monitoring

--- a/falco/README.md
+++ b/falco/README.md
@@ -53,9 +53,9 @@ Falco needs a **driver** to analyze the system workload and pass security events
 
 * [Kernel module](https://falco.org/docs/event-sources/drivers/#kernel-module) 
 * [eBPF probe](https://falco.org/docs/event-sources/drivers/#ebpf-probe)
-* [Modern eBPF probe](https://falco.org/docs/event-sources/drivers/#modern-ebpf-probe-experimental) (starting from Falco `0.34.0`)
+* [Modern eBPF probe](https://falco.org/docs/event-sources/drivers/#modern-ebpf-probe)
 
-The driver should be installed on the node where Falco is running. The _kernel module_ (default option) and the _eBPF probe_ are installed on the node through an *init container* (i.e. `falco-driver-loader`) that tries to build drivers to download a prebuilt driver or build it on-the-fly or as a fallback. The _Modern eBPF probe_ doesn't require an init container because it is shipped directly into the Falco binary. However, the _Modern eBPF probe_ requires a kernel version equal to or greater than `5.8`.
+The driver should be installed on the node where Falco is running. The _kernel module_ (default option) and the _eBPF probe_ are installed on the node through an *init container* (i.e. `falco-driver-loader`) that tries to build drivers to download a prebuilt driver or build it on-the-fly or as a fallback. The _Modern eBPF probe_ doesn't require an init container because it is shipped directly into the Falco binary. However, the _Modern eBPF probe_ requires [recent BPF features](https://falco.org/docs/event-sources/kernel/#modern-ebpf-probe)
 
 ##### Pre-built drivers
 

--- a/falco/generated/helm-values.md
+++ b/falco/generated/helm-values.md
@@ -29,7 +29,7 @@
 | customRules | object | `{}` | Third party rules enabled for Falco. More info on the dedicated section in README.md file. |
 | driver.ebpf | object | `{"hostNetwork":false,"leastPrivileged":false,"path":null}` | Configuration section for ebpf driver. |
 | driver.ebpf.hostNetwork | bool | `false` | Needed to enable eBPF JIT at runtime for performance reasons. Can be skipped if eBPF JIT is enabled from outside the container |
-| driver.ebpf.leastPrivileged | bool | `false` | Constrain Falco with capabilities instead of running a privileged container. This option is only supported with the eBPF driver and a kernel >= 5.8. Ensure the eBPF driver is enabled (i.e., setting the `driver.kind` option to `ebpf`). |
+| driver.ebpf.leastPrivileged | bool | `false` | Constrain Falco with capabilities instead of running a privileged container. Ensure the eBPF driver is enabled (i.e., setting the `driver.kind` option to `ebpf`). Capabilities used: {CAP_SYS_RESOURCE, CAP_SYS_ADMIN, CAP_SYS_PTRACE}. On kernel versions >= 5.8 'CAP_PERFMON' and 'CAP_BPF' could replace 'CAP_SYS_ADMIN' but please pay attention to the 'kernel.perf_event_paranoid' value on your system. Usually 'kernel.perf_event_paranoid>2' means that you cannot use 'CAP_PERFMON' and you should fallback to 'CAP_SYS_ADMIN', but the behavior changes across different distros. Read more on that here: https://falco.org/docs/event-sources/kernel/#least-privileged-mode-1 |
 | driver.ebpf.path | string | `nil` | Path where the eBPF probe is located. It comes handy when the probe have been installed in the nodes using tools other than the init container deployed with the chart. |
 | driver.enabled | bool | `true` | Set it to false if you want to deploy Falco without the drivers. Always set it to false when using Falco with plugins. |
 | driver.kind | string | `"module"` | Tell Falco which driver to use. Available options: module (kernel driver), ebpf (eBPF probe), modern-bpf (modern eBPF probe). |
@@ -42,6 +42,8 @@
 | driver.loader.initContainer.image.repository | string | `"falcosecurity/falco-driver-loader"` | The image repository to pull from. |
 | driver.loader.initContainer.resources | object | `{}` | Resources requests and limits for the Falco driver loader init container. |
 | driver.loader.initContainer.securityContext | object | `{}` | Security context for the Falco driver loader init container. Overrides the default security context. If driver.kind == "module" you must at least set `privileged: true`. |
+| driver.modern_bpf | object | `{"leastPrivileged":false}` | Configuration section for modern bpf driver. |
+| driver.modern_bpf.leastPrivileged | bool | `false` | Constrain Falco with capabilities instead of running a privileged container. Ensure the modern bpf driver is enabled (i.e., setting the `driver.kind` option to `modern-bpf`). Capabilities used: {CAP_SYS_RESOURCE, CAP_BPF, CAP_PERFMON, CAP_SYS_PTRACE}. Read more on that here: https://falco.org/docs/event-sources/kernel/#least-privileged-mode-2 |
 | extra.args | list | `[]` | Extra command-line arguments. |
 | extra.env | list | `[]` | Extra environment variables that will be pass onto Falco containers. |
 | extra.initContainers | list | `[]` | Additional initContainers for Falco pods. |

--- a/falco/generated/helm-values.md
+++ b/falco/generated/helm-values.md
@@ -1,5 +1,5 @@
 # Configuration values for falco chart
-`Chart version: v3.2.1`
+`Chart version: v3.3.0`
 ## Values
 
 | Key | Type | Default | Description |
@@ -114,7 +114,7 @@
 | falcoctl.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy. |
 | falcoctl.image.registry | string | `"docker.io"` | The image registry to pull from. |
 | falcoctl.image.repository | string | `"falcosecurity/falcoctl"` | The image repository to pull from. |
-| falcoctl.image.tag | string | `"0.5.0"` |  |
+| falcoctl.image.tag | string | `"0.5.1"` | The image tag to pull. |
 | falcosidekick | object | `{"enabled":false,"fullfqdn":false,"listenPort":""}` | For configuration values, see https://github.com/falcosecurity/charts/blob/master/falcosidekick/values.yaml |
 | falcosidekick.enabled | bool | `false` | Enable falcosidekick deployment. |
 | falcosidekick.fullfqdn | bool | `false` | Enable usage of full FQDN of falcosidekick service (useful when a Proxy is used). |

--- a/falco/templates/pod-template.tpl
+++ b/falco/templates/pod-template.tpl
@@ -389,11 +389,18 @@ spec:
 {{- define "falco.securityContext" -}}
 {{- $securityContext := dict -}}
 {{- if .Values.driver.enabled -}}
-  {{- if or (eq .Values.driver.kind "module") (eq .Values.driver.kind "modern-bpf") -}}
+  {{- if eq .Values.driver.kind "module" -}}
     {{- $securityContext := set $securityContext "privileged" true -}}
   {{- end -}}
   {{- if eq .Values.driver.kind "ebpf" -}}
     {{- if .Values.driver.ebpf.leastPrivileged -}}
+      {{- $securityContext := set $securityContext "capabilities" (dict "add" (list "SYS_ADMIN" "SYS_RESOURCE" "SYS_PTRACE")) -}}
+    {{- else -}}
+      {{- $securityContext := set $securityContext "privileged" true -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if eq .Values.driver.kind "modern-bpf" -}}
+    {{- if .Values.driver.modern_bpf.leastPrivileged -}}
       {{- $securityContext := set $securityContext "capabilities" (dict "add" (list "BPF" "SYS_RESOURCE" "PERFMON" "SYS_PTRACE")) -}}
     {{- else -}}
       {{- $securityContext := set $securityContext "privileged" true -}}

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -187,8 +187,18 @@ driver:
     # Can be skipped if eBPF JIT is enabled from outside the container
     hostNetwork: false
     # -- Constrain Falco with capabilities instead of running a privileged container.
-    # This option is only supported with the eBPF driver and a kernel >= 5.8.
     # Ensure the eBPF driver is enabled (i.e., setting the `driver.kind` option to `ebpf`).
+    # Capabilities used: {CAP_SYS_RESOURCE, CAP_SYS_ADMIN, CAP_SYS_PTRACE}.
+    # On kernel versions >= 5.8 'CAP_PERFMON' and 'CAP_BPF' could replace 'CAP_SYS_ADMIN' but please pay attention to the 'kernel.perf_event_paranoid' value on your system.
+    # Usually 'kernel.perf_event_paranoid>2' means that you cannot use 'CAP_PERFMON' and you should fallback to 'CAP_SYS_ADMIN', but the behavior changes across different distros.
+    # Read more on that here: https://falco.org/docs/event-sources/kernel/#least-privileged-mode-1
+    leastPrivileged: false
+  # -- Configuration section for modern bpf driver.
+  modern_bpf:
+    # -- Constrain Falco with capabilities instead of running a privileged container.
+    # Ensure the modern bpf driver is enabled (i.e., setting the `driver.kind` option to `modern-bpf`).
+    # Capabilities used: {CAP_SYS_RESOURCE, CAP_BPF, CAP_PERFMON, CAP_SYS_PTRACE}.
+    # Read more on that here: https://falco.org/docs/event-sources/kernel/#least-privileged-mode-2
     leastPrivileged: false
   # -- Configuration for the Falco init container.
   loader:

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -348,8 +348,8 @@ falcoctl:
     registry: docker.io
     # -- The image repository to pull from.
     repository: falcosecurity/falcoctl
-    #  -- Overrides the image tag whose default is the chart appVersion.
-    tag: "0.5.0"
+    # -- The image tag to pull.
+    tag: "0.5.1"
   artifact:
     # -- Runs "falcoctl artifact install" command as an init container. It is used to install artfacts before
     # Falco starts. It provides them to Falco by using an emptyDir volume.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

This PR bumps Falco version to Falco 0.35.1. Main changes:
* support modern ebpf in least privileged mode
* bump falcoctl to 0.5.1

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**

- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
