### PR TITLE
Remove deprecated option and sort volumes alphabetically

### DIFF
--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 3.2.1
+version: 3.2.2
 appVersion: "0.35.0"
 description: Falco
 keywords:

--- a/falco/templates/securitycontextconstraints.yaml
+++ b/falco/templates/securitycontextconstraints.yaml
@@ -17,7 +17,6 @@ allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
 allowedCapabilities: []
-allowedUnsafeSysctls: []
 defaultAddCapabilities: []
 fsGroup:
   type: RunAsAny
@@ -36,8 +35,8 @@ supplementalGroups:
 users:
 - system:serviceaccount:{{ include "falco.namespace" . }}:{{ include "falco.serviceAccountName" . }}
 volumes:
-- hostPath
-- emptyDir
-- secret
 - configMap
+- emptyDir
+- hostPath
+- secret
 {{- end }}


### PR DESCRIPTION
allowedUnsafeSysctls seems to be deprecated for some time now and is automaticly removed when adding the SCC to an Openshift cluster.

The volumes list may cause issues with a default GitOps (ArgoCD) installation as the list was not alphabetically sorted.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

 /area falco-chart

> /area falco-exporter-chart

> /area falcosidekick-chart

> /area event-generator-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
