### PR TITLE
feat(falco-chart): Introduce an ability to use an additional volumeMounts for init containers

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,18 +3,25 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v3.4.0
+
+* Introduce an ability to use an additional volumeMounts from `mounts.volumeMounts` for `falcoctl-artifact-install`, `falcoctl-artifact-follow` and `gvisor-init` init containers.
+
 ## v3.3.0
-* Upgrade Falco to 0.35.1. For more info see the release notes: https://github.com/falcosecurity/falco/releases/tag/0.35.1
-* Upgrade falcoctl to 0.5.1. For more info see the release notes: https://github.com/falcosecurity/falcoctl/releases/tag/v0.5.1
-* Introduce least privileged mode in modern ebpf. For more info see: https://falco.org/docs/event-sources/kernel/#least-privileged-mode-2
- 
+
+* Upgrade Falco to 0.35.1. For more info see the release notes: <https://github.com/falcosecurity/falco/releases/tag/0.35.1>
+* Upgrade falcoctl to 0.5.1. For more info see the release notes: <https://github.com/falcosecurity/falcoctl/releases/tag/v0.5.1>
+* Introduce least privileged mode in modern ebpf. For more info see: <https://falco.org/docs/event-sources/kernel/#least-privileged-mode-2>
+
 ## v3.2.1
+
 * Set falco.http_output.url to empty string in values.yaml file
 
 ## v3.2.0
-* Upgrade Falco to 0.35.0. For more info see the release notes: https://github.com/falcosecurity/falco/releases/tag/0.35.0
+
+* Upgrade Falco to 0.35.0. For more info see the release notes: <https://github.com/falcosecurity/falco/releases/tag/0.35.0>
 * Sync values.yaml with upstream falco.yaml config file.
-* Upgrade falcoctl to 0.5.0. For more info see the release notes: https://github.com/falcosecurity/falcoctl/releases/tag/v0.5.0
+* Upgrade falcoctl to 0.5.0. For more info see the release notes: <https://github.com/falcosecurity/falcoctl/releases/tag/v0.5.0>
 * The tag used to install and follow the falco rules is `1`
 * The tag used to install and follow the k8saudit rules is `0.6`
 
@@ -35,12 +42,15 @@ numbering uses [semantic versioning](http://semver.org).
 * Bump `falcosidekick` dependency to 0.6.1
 
 ## v3.1.1
+
 * Update `k8saudit` section in README.md file.
 
 ## v3.1.0
+
 * Upgrade Falco to 0.34.1
 
 ## v3.0.0
+
 * Drop support for falcosecuriy/falco image, only the init container approach is supported out of the box;
 * Simplify the driver-loader init container logic;
 * Support **falcoctl** tool in the chart:
@@ -55,7 +65,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 ## v2.5.4
 
-* Fix incorrect entry in v2.5.2 changelog 
+* Fix incorrect entry in v2.5.2 changelog
 
 ## v2.5.3
 
@@ -73,7 +83,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 * Support custom dictionaries when setting environment variables
 
-Note: this is a breaking change. If you were passing _objects_ to `extra.env` or `driver.loader.initContainer.env` , you will need to update your values file to pass _lists_.
+Note: this is a breaking change. If you were passing *objects* to `extra.env` or `driver.loader.initContainer.env` , you will need to update your values file to pass *lists*.
 
 ## v2.4.7
 
@@ -106,7 +116,7 @@ Note: this is a breaking change. If you were passing _objects_ to `extra.env` or
 ## v2.4.0
 
 * Add support for Falco+gVisor
-* Add new preset `values.yaml `file for gVisor-enabled GKE clusters
+* Add new preset `values.yaml`file for gVisor-enabled GKE clusters
 
 ## v2.3.1
 
@@ -435,6 +445,7 @@ Remove whitespace around `falco.httpOutput.url` to fix the error `libcurl error:
 ## v1.7.6
 
 * Correct icon URL
+
 ## v1.7.5
 
 * Update downstream sidekick chart
@@ -496,7 +507,7 @@ Remove whitespace around `falco.httpOutput.url` to fix the error `libcurl error:
 
 ### Minor Changes
 
-* Upgrade to Falco 0.26.2, `DRIVERS_REPO` now defaults to https://download.falco.org/driver (see the [Falco changelog](https://github.com/falcosecurity/falco/blob/0.26.2/CHANGELOG.md))
+* Upgrade to Falco 0.26.2, `DRIVERS_REPO` now defaults to <https://download.falco.org/driver> (see the [Falco changelog](https://github.com/falcosecurity/falco/blob/0.26.2/CHANGELOG.md))
 
 ## v1.5.3
 

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 3.3.0
+version: 3.4.0
 appVersion: "0.35.1"
 description: Falco
 keywords:

--- a/falco/templates/_helpers.tpl
+++ b/falco/templates/_helpers.tpl
@@ -249,6 +249,9 @@ be temporary and will stay here until we move this logic to the falcoctl tool.
       name: runsc-config
     - mountPath: /gvisor-config
       name: falco-gvisor-config
+      {{- with .Values.mounts.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
 {{- end -}}
 
 
@@ -277,6 +280,9 @@ be temporary and will stay here until we move this logic to the falcoctl tool.
       name: rulesfiles-install-dir
     - mountPath: /etc/falcoctl
       name: falcoctl-config-volume
+      {{- with .Values.mounts.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
   env:
   {{- if .Values.falcoctl.artifact.install.env }}
   {{- include "falco.renderTemplate" ( dict "value" .Values.falcoctl.artifact.install.env "context" $) | nindent 4 }}
@@ -308,6 +314,9 @@ be temporary and will stay here until we move this logic to the falcoctl tool.
       name: rulesfiles-install-dir
     - mountPath: /etc/falcoctl
       name: falcoctl-config-volume
+      {{- with .Values.mounts.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
   env:
   {{- if .Values.falcoctl.artifact.follow.env }}
   {{- include "falco.renderTemplate" ( dict "value" .Values.falcoctl.artifact.follow.env "context" $) | nindent 4 }}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

Add an ability to use the same custom extra volumeMounts for init containers (`falco-artifact-install`, `falco-artifact-follow`, `gvisor-init`). Usage of additional volumeMounts will solve the challenge when user need an ability to mount a pre-defined credentials helper config (like docker's `config.json`). 

Example case:
* Add a custom initContainer with credentials helper config generation, e.g. to generate a credentials for AWS ECR with `aws ecr get-login-password`
* Now we need to pass generated config to `falco-artifact-install` and `falco-artifact-follow` initContainers to auth against AWS ECR without specifying `FALCOCTL_REGISTRY_AUTH_*` env var or specific config for `falcoctl`

**Checklist**
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
