### PR TITLE
feat: allow changing the default revisionHistoryLimit

### DIFF
--- a/event-generator/CHANGELOG.md
+++ b/event-generator/CHANGELOG.md
@@ -4,6 +4,12 @@
 This file documents all notable changes to `event-generator` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.3.0
+
+## Major Changes
+
+* Support configuration of revisionHistoryLimit of the deployment
+
 ## v0.2.0
 
 ## Major Changes

--- a/event-generator/Chart.yaml
+++ b/event-generator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/event-generator/templates/deployment.yaml
+++ b/event-generator/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- include "event-generator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicasCount }}
+  {{- if .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "event-generator.selectorLabels" . | nindent 6 }}

--- a/event-generator/values.yaml
+++ b/event-generator/values.yaml
@@ -5,6 +5,9 @@
 # -- Number of replicas of the event-generator (meaningful when installed as a deployment).
 replicasCount: 1
 
+# -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+# revisionHistoryLimit: 1
+
 image:
   # -- Repository from where the image is pulled.
   repository: falcosecurity/event-generator

--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v3.5.0
+
+## Major Changes
+
+* Support configuration of revisionHistoryLimit of the deployment
+
 ## v3.4.1
 
 * Upgrade falcosidekick chart to `v0.6.3`.

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 3.4.1
+version: 3.5.0
 appVersion: "0.35.1"
 description: Falco
 keywords:

--- a/falco/templates/deployment.yaml
+++ b/falco/templates/deployment.yaml
@@ -12,6 +12,9 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.controller.deployment.replicas }}
+  {{- if .Values.controller.deployment.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.controller.deployment.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "falco.selectorLabels" . | nindent 6 }}

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -150,6 +150,8 @@ controller:
     # -- Number of replicas when installing Falco using a deployment. Change it if you really know what you are doing.
     # For more info check the section on Plugins in the README.md file.
     replicas: 1
+    # -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+    # revisionHistoryLimit: 1
 
 # -- Network services configuration (scenario requirement)
 # Add here your services to be deployed together with Falco.

--- a/falcosidekick/CHANGELOG.md
+++ b/falcosidekick/CHANGELOG.md
@@ -5,6 +5,12 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.7.0
+
+## Major Changes
+
+* Support configuration of revisionHistoryLimit of the deployments
+
 ## 0.6.3
 
 * Update Falcosidekick to 2.28.0

--- a/falcosidekick/Chart.yaml
+++ b/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.28.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.6.3
+version: 0.7.0
 keywords:
   - monitoring
   - security

--- a/falcosidekick/templates/deployment-ui.yaml
+++ b/falcosidekick/templates/deployment-ui.yaml
@@ -17,6 +17,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.webui.replicaCount }}
+  {{- if .Values.webui.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.webui.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "falcosidekick.name" . }}-ui

--- a/falcosidekick/templates/deployment.yaml
+++ b/falcosidekick/templates/deployment.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "falcosidekick.name" . }}

--- a/falcosidekick/values.yaml
+++ b/falcosidekick/values.yaml
@@ -5,6 +5,9 @@
 # -- number of running pods
 replicaCount: 2
 
+# -- number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+# revisionHistoryLimit: 1
+
 image:
   # -- The image registry to pull from
   registry: docker.io
@@ -937,6 +940,8 @@ webui:
   enabled: false
   # -- number of running pods
   replicaCount: 2
+  # -- number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+  # revisionHistoryLimit: 1
   # -- Log level ("debug", "info", "warning", "error")
   loglevel: "info"
   # -- TTL for keys (0 for no ttl)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falco-chart

/area falcosidekick-chart

/area event-generator-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

I want to clean up old replica sets so that these don't appear in metrics, OPA violations, ArgoCD UI and so on.
Therefore I want to overwrite the Kubernetes default revision history limit.

See [Kubernetes Clean up Policy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

N/A

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] CHANGELOG.md updated
