### PR TITLE
chore(falco-chart): update falcoctl version since it's outdated

### DIFF
--- a/falco/CHANGELOG.md
+++ b/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v3.7.2
+
+* Update falcoctl version to 0.6.1
+
 ## v3.6.2
 
 * Cleanup wrong files

--- a/falco/Chart.yaml
+++ b/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 3.6.2
+version: 3.7.2
 appVersion: "0.35.1"
 description: Falco
 keywords:

--- a/falco/generated/helm-values.md
+++ b/falco/generated/helm-values.md
@@ -117,7 +117,7 @@
 | falcoctl.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy. |
 | falcoctl.image.registry | string | `"docker.io"` | The image registry to pull from. |
 | falcoctl.image.repository | string | `"falcosecurity/falcoctl"` | The image repository to pull from. |
-| falcoctl.image.tag | string | `"0.5.1"` | The image tag to pull. |
+| falcoctl.image.tag | string | `"0.6.1"` | The image tag to pull. |
 | falcosidekick | object | `{"enabled":false,"fullfqdn":false,"listenPort":""}` | For configuration values, see https://github.com/falcosecurity/charts/blob/master/falcosidekick/values.yaml |
 | falcosidekick.enabled | bool | `false` | Enable falcosidekick deployment. |
 | falcosidekick.fullfqdn | bool | `false` | Enable usage of full FQDN of falcosidekick service (useful when a Proxy is used). |

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -351,7 +351,7 @@ falcoctl:
     # -- The image repository to pull from.
     repository: falcosecurity/falcoctl
     # -- The image tag to pull.
-    tag: "0.5.1"
+    tag: "0.6.1"
   artifact:
     # -- Runs "falcoctl artifact install" command as an init container. It is used to install artfacts before
     # Falco starts. It provides them to Falco by using an emptyDir volume.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:
The 'default' version of `falcoctl` in the chart's `values.yaml` is outdated. This is confusing and may lead to unexpected `falcoctl` behaviour. 

**Which issue(s) this PR fixes**:
`-`

**Checklist**
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
