### PR TITLE
Feature: Deploy falcosidekick and falco server and client secrets for mTLS

### DIFF
--- a/falco/templates/client-certs-secret.yaml
+++ b/falco/templates/client-certs-secret.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.certs.client.key .Values.certs.client.crt .Values.certs.ca.crt }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "falco.fullname" . }}-client-certs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "falco.name" . }}
+    helm.sh/chart: {{ include "falco.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  {{ $key := .Values.certs.client.key }}
+  client.key: {{ $key | b64enc | quote }}
+  {{ $crt := .Values.certs.client.crt }}
+  client.crt: {{ $crt | b64enc | quote }}
+  falcoclient.pem: {{ print $key $crt | b64enc | quote }}
+  ca.crt: {{ .Values.certs.ca.crt | b64enc | quote }}
+  ca.pem: {{ .Values.certs.ca.crt | b64enc | quote }}
+{{- end }}

--- a/falco/templates/pod-template.tpl
+++ b/falco/templates/pod-template.tpl
@@ -201,6 +201,11 @@ spec:
           name: certs-volume
           readOnly: true
         {{- end }}
+        {{- if or .Values.certs.existingSecret (and .Values.certs.client.key .Values.certs.client.crt .Values.certs.ca.crt) }}
+        - mountPath: /etc/falco/certs/client
+          name: client-certs-volume
+          readOnly: true
+        {{- end }}
         {{- include "falco.unixSocketVolumeMount"  . | nindent 8 -}}
         {{- with .Values.mounts.volumeMounts }}
           {{- toYaml . | nindent 8 }}
@@ -333,6 +338,15 @@ spec:
         secretName: {{ .Values.certs.existingSecret }}
         {{- else }}
         secretName: {{ include "falco.fullname" . }}-certs
+        {{- end }}
+    {{- end }}
+    {{- if or .Values.certs.existingSecret (and .Values.certs.client.key .Values.certs.client.crt .Values.certs.ca.crt) }}
+    - name: client-certs-volume
+      secret:
+        {{- if .Values.certs.existingClientSecret }}
+        secretName: {{ .Values.certs.existingClientSecret }}
+        {{- else }}
+        secretName: {{ include "falco.fullname" . }}-client-certs
         {{- end }}
     {{- end }}
     {{- include "falco.unixSocketVolume" . | nindent 4 -}}

--- a/falco/values.yaml
+++ b/falco/values.yaml
@@ -313,6 +313,13 @@ certs:
   ca:
     # -- CA certificate used by gRPC, webserver and AuditSink validation.
     crt: ""
+  existingClientSecret: ""
+  client:
+    # -- Key used by http mTLS client.
+    key: ""
+    # -- Certificate used by http mTLS client.
+    crt: ""
+
 # -- Third party rules enabled for Falco. More info on the dedicated section in README.md file.
 customRules:
   {}
@@ -715,13 +722,13 @@ falco:
     ca_bundle: ""
     # -- Path to a folder that will be used as the CA certificate store. CA certificate need to be
     # stored as indivitual PEM files in this directory.
-    ca_path: "/etc/ssl/certs"
+    ca_path: "/etc/falco/certs/"
     # -- Tell Falco to use mTLS
     mtls: false
     # -- Path to the client cert.
-    client_cert: "/etc/ssl/certs/client.crt"
+    client_cert: "/etc/falco/certs/client/client.crt"
     # -- Path to the client key.
-    client_key: "/etc/ssl/certs/client.key"
+    client_key: "/etc/falco/certs/client/client.key"
     # -- Whether to echo server answers to stdout
     echo: false
 

--- a/falcosidekick/README.md
+++ b/falcosidekick/README.md
@@ -514,6 +514,10 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | config.zincsearch.password | string | `""` | use this password to authenticate to ZincSearch |
 | config.zincsearch.username | string | `""` | use this username to authenticate to ZincSearch |
 | extraVolumeMounts | list | `[]` | Extra volume mounts for sidekick deployment |
+| certs.existingSecret | string | `""` | Existing secret containing the following key, crt and ca as well as the bundle pem. |
+| certs.server.key | string | `""` | Key used by mTLS webserver. |
+| certs.server.crt | string | `""` | Certificate used by mTLS webserver. |
+| certs.ca.crt | string | `""` | CA certificate used by server Client Certificate validation |
 | extraVolumes | list | `[]` | Extra volumes for sidekick deployment |
 | fullnameOverride | string | `""` | Override the name |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |

--- a/falcosidekick/README.md
+++ b/falcosidekick/README.md
@@ -514,10 +514,6 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | config.zincsearch.password | string | `""` | use this password to authenticate to ZincSearch |
 | config.zincsearch.username | string | `""` | use this username to authenticate to ZincSearch |
 | extraVolumeMounts | list | `[]` | Extra volume mounts for sidekick deployment |
-| certs.existingSecret | string | `""` | Existing secret containing the following key, crt and ca as well as the bundle pem. |
-| certs.server.key | string | `""` | Key used by mTLS webserver. |
-| certs.server.crt | string | `""` | Certificate used by mTLS webserver. |
-| certs.ca.crt | string | `""` | CA certificate used by server Client Certificate validation |
 | extraVolumes | list | `[]` | Extra volumes for sidekick deployment |
 | fullnameOverride | string | `""` | Override the name |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |

--- a/falcosidekick/templates/certs-secret.yaml
+++ b/falcosidekick/templates/certs-secret.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.certs.server.key .Values.certs.server.crt .Values.certs.ca.crt }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "falcosidekick.fullname" . }}-certs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "falcosidekick.name" . }}
+    helm.sh/chart: {{ include "falcosidekick.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  {{ $key := .Values.certs.server.key }}
+  server.key: {{ $key | b64enc | quote }}
+  {{ $crt := .Values.certs.server.crt }}
+  server.crt: {{ $crt | b64enc | quote }}
+  falcosidekick.pem: {{ print $key $crt | b64enc | quote }}
+  ca.crt: {{ .Values.certs.ca.crt | b64enc | quote }}
+  ca.pem: {{ .Values.certs.ca.crt | b64enc | quote }}
+{{- end }}

--- a/falcosidekick/templates/deployment.yaml
+++ b/falcosidekick/templates/deployment.yaml
@@ -57,16 +57,29 @@ spec:
             - name: http
               containerPort: 2801
               protocol: TCP
+          {{- if .Values.config.tlsserver.deploy }}
+            - name: http-notls
+              containerPort: 2810
+              protocol: TCP
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /ping
+              {{- if .Values.config.tlsserver.deploy }}
+              port: http-notls
+              {{- else }}
               port: http
+              {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /ping
+              {{- if .Values.config.tlsserver.deploy }}
+              port: http-notls
+              {{- else }}
               port: http
+              {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 5
           {{- if .Values.securityContext }}
@@ -117,10 +130,17 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.extraVolumeMounts }}
+        {{- if or .Values.extraVolumeMounts .Values.certs }}
           volumeMounts:
+        {{- if or .Values.certs.existingSecret (and .Values.certs.server.key .Values.certs.server.crt .Values.certs.ca.crt) }}
+            - mountPath: /etc/falcosidekick/certs
+              name: certs-volume
+              readOnly: true
+        {{- end }}  
+        {{- if or .Values.extraVolumeMounts }}   
 {{ toYaml .Values.extraVolumeMounts | indent 12 }}
-          {{- end }}
+        {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -133,8 +153,19 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.extraVolumes }}
+    {{- if or .Values.extraVolumes .Values.certs.existingSecret (and .Values.certs.server.key .Values.certs.server.crt .Values.certs.ca.crt) }}
       volumes:
+    {{- if or .Values.certs.existingSecret (and .Values.certs.server.key .Values.certs.server.crt .Values.certs.ca.crt) }}
+        - name: certs-volume
+          secret:
+            {{- if .Values.certs.existingSecret }}
+            secretName: {{ .Values.certs.existingSecret }}
+            {{- else }}
+            secretName: {{ include "falcosidekick.fullname" . }}-certs
+            {{- end }}
+    {{- end }}
+    {{- if or .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8 }}
+    {{- end }}
     {{- end }}
 

--- a/falcosidekick/templates/service.yaml
+++ b/falcosidekick/templates/service.yaml
@@ -26,6 +26,12 @@ spec:
       protocol: TCP
       name: http-notls
     {{- end }}
+    {{- if not (eq .Values.config.tlsserver.notlspaths "") }}
+    - port: {{ .Values.config.tlsserver.notlsport }}
+      targetPort: http-notls
+      protocol: TCP
+      name: http-notls
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "falcosidekick.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/falcosidekick/templates/service.yaml
+++ b/falcosidekick/templates/service.yaml
@@ -20,6 +20,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if not (eq .Values.config.tlsserver.notlspaths "") }}
+    - port: {{ .Values.config.tlsserver.notlsport }}
+      targetPort: http-notls
+      protocol: TCP
+      name: http-notls
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "falcosidekick.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/falcosidekick/values.yaml
+++ b/falcosidekick/values.yaml
@@ -63,7 +63,7 @@ config:
   # -- if not empty, the brackets in keys of Output Fields are replaced
   bracketreplacer: ""
   # -- folder which will used to store client.crt, client.key and ca.crt files for mutual tls for outputs, will be deprecated in the future (default: "/etc/certs")
-  mutualtlsfilespath: "/etc/certs"
+  mutualtlsfilespath: "/etc/falcosidekick/certs"
 
   mutualtlsclient:
     # -- client certification file for mutual TLS client certification, takes priority over mutualtlsfilespath if not empty
@@ -77,13 +77,13 @@ config:
     # -- if true TLS server will be deployed instead of HTTP
     deploy: false
     # -- server certification file for TLS Server
-    certfile: "/etc/certs/server/server.crt"
+    certfile: "/etc/falcosidekick/certs/server.crt"
     # -- server key file for TLS Server
-    keyfile: "/etc/certs/server/server.key"
+    keyfile: "/etc/falcosidekick/certs/server.key"
     # -- if true mutual TLS server will be deployed instead of TLS, deploy also has to be true
     mutualtls: false
     # --  CA certification file for client certification if mutualtls is true
-    cacertfile: "/etc/certs/server/ca.crt"
+    cacertfile: "/etc/falcosidekick/certs/ca.crt"
     # -- port to serve http server serving selected endpoints
     notlsport: 2810
     # -- a comma separated list of endpoints, if not empty, a separate http server will be deployed for the specified endpoints
@@ -924,6 +924,19 @@ extraVolumes: []
 extraVolumeMounts: []
 # - mountPath: /etc/certs/mtlscert.optional.tls
 #   name: optional-mtls-volume
+
+# -- Certificates for mutual TLS server
+certs:
+  # -- Existing secret containing the following key, crt and ca as well as the bundle pem.
+  existingSecret: ""
+  server:
+    # -- Key used by gRPC and webserver.
+    key: ""
+    # -- Certificate used by gRPC and webserver.
+    crt: ""
+  ca:
+    # -- CA certificate used by gRPC, webserver and AuditSink validation.
+    crt: ""
 
 testConnection:
   # -- test connection nodeSelector field

--- a/falcosidekick/values.yaml
+++ b/falcosidekick/values.yaml
@@ -930,12 +930,12 @@ certs:
   # -- Existing secret containing the following key, crt and ca as well as the bundle pem.
   existingSecret: ""
   server:
-    # -- Key used by mTLS webserver.
+    # -- Key used by gRPC and webserver.
     key: ""
-    # -- Certificate used by mTLS webserver.
+    # -- Certificate used by gRPC and webserver.
     crt: ""
   ca:
-    # -- CA certificate used by server Client Certificate validation.
+    # -- CA certificate used by gRPC, webserver and AuditSink validation.
     crt: ""
 
 testConnection:

--- a/falcosidekick/values.yaml
+++ b/falcosidekick/values.yaml
@@ -930,12 +930,12 @@ certs:
   # -- Existing secret containing the following key, crt and ca as well as the bundle pem.
   existingSecret: ""
   server:
-    # -- Key used by gRPC and webserver.
+    # -- Key used by mTLS webserver.
     key: ""
-    # -- Certificate used by gRPC and webserver.
+    # -- Certificate used by mTLS webserver.
     crt: ""
   ca:
-    # -- CA certificate used by gRPC, webserver and AuditSink validation.
+    # -- CA certificate used by server Client Certificate validation.
     crt: ""
 
 testConnection:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falco-chart

/area falcosidekick-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds the capability of loading certificates dynamically via helm values, instead mounting volumes. It's structured in a way to make it easier to deploy mTLS cryptographic material for both falco and falcosidekick when http_output is enabled.

**Which issue(s) this PR fixes**:
 
N/A

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

There are some changes in the directories to store the certificates. It seems not to break anything, but this of course can be overridden by a local values file. 

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Variables are documented in the README.md
