### PR TITLE
Feature: Add mTLS certificate loading for Falco Sidekick via Helm

### DIFF
--- a/falcosidekick/CHANGELOG.md
+++ b/falcosidekick/CHANGELOG.md
@@ -5,6 +5,9 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.7.3
+
+* Allow to set (m)TLS Server cryptographic material via `config.tlsserver.servercrt`, `config.tlsserver.serverkey` and `config.tlsserver.cacrt` variables or through `config.tlsserver.existingSecret` variables.
 
 ## 0.7.2
 

--- a/falcosidekick/Chart.yaml
+++ b/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.28.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.7.2
+version: 0.7.3
 keywords:
   - monitoring
   - security

--- a/falcosidekick/README.md
+++ b/falcosidekick/README.md
@@ -481,7 +481,7 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | config.tlsserver.deploy | bool | `false` | if true TLS server will be deployed instead of HTTP |
 | config.tlsserver.keyfile | string | `"/etc/certs/server/server.key"` | server key file for TLS Server |
 | config.tlsserver.mutualtls | bool | `false` | if true mutual TLS server will be deployed instead of TLS, deploy also has to be true |
-| config.tlsserver.notlspaths | string | `""` | a comma separated list of endpoints, if not empty, a separate http server will be deployed for the specified endpoints |
+| config.tlsserver.notlspaths | string | `"/ping"` | a comma separated list of endpoints, if not empty, a separate http server will be deployed for the specified endpoints. Default value is /ping for livenessProbe and readinessProbe not to fail. |
 | config.tlsserver.notlsport | int | `2810` | port to serve http server serving selected endpoints |
 | config.wavefront.batchsize | int | `10000` | Wavefront batch size. If empty uses the default 10000. Only used when endpointtype is 'direct' |
 | config.wavefront.endpointhost | string | `""` | Wavefront endpoint address (only the host). If not empty, with endpointhost, Wavefront output is *enabled* |
@@ -514,6 +514,10 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | config.zincsearch.password | string | `""` | use this password to authenticate to ZincSearch |
 | config.zincsearch.username | string | `""` | use this username to authenticate to ZincSearch |
 | extraVolumeMounts | list | `[]` | Extra volume mounts for sidekick deployment |
+| certs.existingSecret | string | `""` | Existing secret containing the following key, crt and ca as well as the bundle pem |
+| certs.server.key | string | `""` | Server Key to authenticate with the clients |
+| certs.server.crt | string | `""` | Server Certificate to authenticate with the clients |
+| certs.ca.crt | string | `""` | CA certificate to validate the clients |
 | extraVolumes | list | `[]` | Extra volumes for sidekick deployment |
 | fullnameOverride | string | `""` | Override the name |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |

--- a/falcosidekick/README.md
+++ b/falcosidekick/README.md
@@ -485,7 +485,7 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | config.tlsserver.serverkey | string | `""` | server.key file path for TLS Server |
 | config.tlsserver.keyfile | string | `"/etc/certs/server/server.key"` | server key file path for TLS Server |
 | config.tlsserver.mutualtls | bool | `false` | if true mutual TLS server will be deployed instead of TLS, deploy also has to be true |
-| config.tlsserver.notlspaths | string | `"/ping"` | a comma separated list of endpoints. A separate http server will be deployed for the specified endpoints. Ping endpoint needs to be notls for Kubernetes to be able to check the health of the pod |
+| config.tlsserver.notlspaths | string | `"/ping"` | a comma separated list of endpoints, if not empty, and tlsserver.deploy is true, a separate http server will be deployed for the specified endpoints (/ping endpoint needs to be notls for Kubernetes to be able to perform the healthchecks) |
 | config.tlsserver.notlsport | int | `2810` | port to serve http server serving selected endpoints |
 | config.wavefront.batchsize | int | `10000` | Wavefront batch size. If empty uses the default 10000. Only used when endpointtype is 'direct' |
 | config.wavefront.endpointhost | string | `""` | Wavefront endpoint address (only the host). If not empty, with endpointhost, Wavefront output is *enabled* |

--- a/falcosidekick/README.md
+++ b/falcosidekick/README.md
@@ -476,12 +476,16 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | config.timescaledb.password | string | `"postgres"` | Password to authenticate with TimescaleDB |
 | config.timescaledb.port | int | `5432` | TimescaleDB port (default: 5432) |
 | config.timescaledb.user | string | `"postgres"` | Username to authenticate with TimescaleDB |
-| config.tlsserver.cacertfile | string | `"/etc/certs/server/ca.crt"` | CA certification file for client certification if mutualtls is true |
-| config.tlsserver.certfile | string | `"/etc/certs/server/server.crt"` | server certification file for TLS Server |
+| config.tlsserver.existingSecret | string | `""` | existing secret with server.crt, server.key and ca.crt files for TLS Server |
+| config.tlsserver.cacrt | string | `""` | ca.crt file for client certification if mutualtls is true |
+| config.tlsserver.cacertfile | string | `"/etc/certs/server/ca.crt"` | CA certification file path for client certification if mutualtls is true |
+| config.tlsserver.servercrt | string | `""` | server.crt file for TLS Server |
+| config.tlsserver.certfile | string | `"/etc/certs/server/server.crt"` | server certification file path for TLS Server |
 | config.tlsserver.deploy | bool | `false` | if true TLS server will be deployed instead of HTTP |
-| config.tlsserver.keyfile | string | `"/etc/certs/server/server.key"` | server key file for TLS Server |
+| config.tlsserver.serverkey | string | `""` | server.key file path for TLS Server |
+| config.tlsserver.keyfile | string | `"/etc/certs/server/server.key"` | server key file path for TLS Server |
 | config.tlsserver.mutualtls | bool | `false` | if true mutual TLS server will be deployed instead of TLS, deploy also has to be true |
-| config.tlsserver.notlspaths | string | `"/ping"` | a comma separated list of endpoints, if not empty, a separate http server will be deployed for the specified endpoints. Default value is /ping for livenessProbe and readinessProbe not to fail. |
+| config.tlsserver.notlspaths | string | `"/ping"` | a comma separated list of endpoints. A separate http server will be deployed for the specified endpoints. Ping endpoint needs to be notls for Kubernetes to be able to check the health of the pod |
 | config.tlsserver.notlsport | int | `2810` | port to serve http server serving selected endpoints |
 | config.wavefront.batchsize | int | `10000` | Wavefront batch size. If empty uses the default 10000. Only used when endpointtype is 'direct' |
 | config.wavefront.endpointhost | string | `""` | Wavefront endpoint address (only the host). If not empty, with endpointhost, Wavefront output is *enabled* |
@@ -514,10 +518,6 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | config.zincsearch.password | string | `""` | use this password to authenticate to ZincSearch |
 | config.zincsearch.username | string | `""` | use this username to authenticate to ZincSearch |
 | extraVolumeMounts | list | `[]` | Extra volume mounts for sidekick deployment |
-| certs.existingSecret | string | `""` | Existing secret containing the following key, crt and ca as well as the bundle pem |
-| certs.server.key | string | `""` | Server Key to authenticate with the clients |
-| certs.server.crt | string | `""` | Server Certificate to authenticate with the clients |
-| certs.ca.crt | string | `""` | CA certificate to validate the clients |
 | extraVolumes | list | `[]` | Extra volumes for sidekick deployment |
 | fullnameOverride | string | `""` | Override the name |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |

--- a/falcosidekick/templates/certs-secret.yaml
+++ b/falcosidekick/templates/certs-secret.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.certs.server.key .Values.certs.server.crt .Values.certs.ca.crt }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "falcosidekick.fullname" . }}-certs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "falcosidekick.name" . }}
+    helm.sh/chart: {{ include "falcosidekick.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  {{ $key := .Values.certs.server.key }}
+  server.key: {{ $key | b64enc | quote }}
+  {{ $crt := .Values.certs.server.crt }}
+  server.crt: {{ $crt | b64enc | quote }}
+  falcosidekick.pem: {{ print $key $crt | b64enc | quote }}
+  ca.crt: {{ .Values.certs.ca.crt | b64enc | quote }}
+  ca.pem: {{ .Values.certs.ca.crt | b64enc | quote }}
+{{- end }}

--- a/falcosidekick/templates/certs-secret.yaml
+++ b/falcosidekick/templates/certs-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certs.server.key .Values.certs.server.crt .Values.certs.ca.crt }}
+{{- if and .Values.config.tlsserver.serverkey .Values.config.tlsserver.servercrt .Values.config.tlsserver.cacrt }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,11 +11,11 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
-  {{ $key := .Values.certs.server.key }}
+  {{ $key := .Values.config.tlsserver.serverkey }}
   server.key: {{ $key | b64enc | quote }}
-  {{ $crt := .Values.certs.server.crt }}
+  {{ $crt := .Values.config.tlsserver.servercrt }}
   server.crt: {{ $crt | b64enc | quote }}
   falcosidekick.pem: {{ print $key $crt | b64enc | quote }}
-  ca.crt: {{ .Values.certs.ca.crt | b64enc | quote }}
-  ca.pem: {{ .Values.certs.ca.crt | b64enc | quote }}
+  ca.crt: {{ .Values.config.tlsserver.cacrt | b64enc | quote }}
+  ca.pem: {{ .Values.config.tlsserver.cacrt | b64enc | quote }}
 {{- end }}

--- a/falcosidekick/templates/deployment.yaml
+++ b/falcosidekick/templates/deployment.yaml
@@ -132,7 +132,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if or .Values.extraVolumeMounts .Values.certs }}
           volumeMounts:
-        {{- if or .Values.certs.existingSecret (and .Values.certs.server.key .Values.certs.server.crt .Values.certs.ca.crt) }}
+        {{- if or .Values.config.tlsserver.existingSecret (and .Values.config.tlsserver.serverkey .Values.config.tlsserver.servercrt .Values.config.tlsserver.cacrt) }}
             - mountPath: /etc/certs/server
               name: certs-volume
               readOnly: true
@@ -153,13 +153,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if or .Values.extraVolumes .Values.certs.existingSecret (and .Values.certs.server.key .Values.certs.server.crt .Values.certs.ca.crt) }}
+    {{- if or .Values.extraVolumes .Values.config.tlsserver.existingSecret (and .Values.config.tlsserver.serverkey .Values.config.tlsserver.servercrt .Values.config.tlsserver.cacrt) }}
       volumes:
-    {{- if or .Values.certs.existingSecret (and .Values.certs.server.key .Values.certs.server.crt .Values.certs.ca.crt) }}
+    {{- if or .Values.config.tlsserver.existingSecret (and .Values.config.tlsserver.serverkey .Values.config.tlsserver.servercrt .Values.config.tlsserver.cacrt) }}
         - name: certs-volume
           secret:
-            {{- if .Values.certs.existingSecret }}
-            secretName: {{ .Values.certs.existingSecret }}
+            {{- if .Values.config.tlsserver.existingSecret }}
+            secretName: {{.Values.config.tlsserver.existingSecret }}
             {{- else }}
             secretName: {{ include "falcosidekick.fullname" . }}-certs
             {{- end }}

--- a/falcosidekick/templates/deployment.yaml
+++ b/falcosidekick/templates/deployment.yaml
@@ -57,16 +57,29 @@ spec:
             - name: http
               containerPort: 2801
               protocol: TCP
+          {{- if .Values.config.tlsserver.deploy }}
+            - name: http-notls
+              containerPort: 2810
+              protocol: TCP
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /ping
+              {{- if .Values.config.tlsserver.deploy }}
+              port: http-notls
+              {{- else }}
               port: http
+              {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /ping
+              {{- if .Values.config.tlsserver.deploy }}
+              port: http-notls
+              {{- else }}
               port: http
+              {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 5
           {{- if .Values.securityContext }}
@@ -117,10 +130,17 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.extraVolumeMounts }}
+        {{- if or .Values.extraVolumeMounts .Values.certs }}
           volumeMounts:
+        {{- if or .Values.certs.existingSecret (and .Values.certs.server.key .Values.certs.server.crt .Values.certs.ca.crt) }}
+            - mountPath: /etc/certs/server
+              name: certs-volume
+              readOnly: true
+        {{- end }}  
+        {{- if or .Values.extraVolumeMounts }}   
 {{ toYaml .Values.extraVolumeMounts | indent 12 }}
-          {{- end }}
+        {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -133,8 +153,19 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.extraVolumes }}
+    {{- if or .Values.extraVolumes .Values.certs.existingSecret (and .Values.certs.server.key .Values.certs.server.crt .Values.certs.ca.crt) }}
       volumes:
+    {{- if or .Values.certs.existingSecret (and .Values.certs.server.key .Values.certs.server.crt .Values.certs.ca.crt) }}
+        - name: certs-volume
+          secret:
+            {{- if .Values.certs.existingSecret }}
+            secretName: {{ .Values.certs.existingSecret }}
+            {{- else }}
+            secretName: {{ include "falcosidekick.fullname" . }}-certs
+            {{- end }}
+    {{- end }}
+    {{- if or .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8 }}
+    {{- end }}
     {{- end }}
 

--- a/falcosidekick/templates/service.yaml
+++ b/falcosidekick/templates/service.yaml
@@ -20,6 +20,13 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if not (eq .Values.config.tlsserver.notlspaths "") }}
+    - port: {{ .Values.config.tlsserver.notlsport }}
+      targetPort: http-notls
+      protocol: TCP
+      name: http-notls
+    {{- end }}
+
   selector:
     app.kubernetes.io/name: {{ include "falcosidekick.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/falcosidekick/values.yaml
+++ b/falcosidekick/values.yaml
@@ -94,7 +94,7 @@ config:
     cacertfile: "/etc/certs/server/ca.crt"
     # -- port to serve http server serving selected endpoints
     notlsport: 2810
-    # -- a comma separated list of endpoints. A separate http server will be deployed for the specified endpoints. Ping endpoint needs to be notls for Kubernetes to be able to check the health of the pod
+    # -- a comma separated list of endpoints, if not empty, and tlsserver.deploy is true, a separate http server will be deployed for the specified endpoints (/ping endpoint needs to be notls for Kubernetes to be able to perform the healthchecks)
     notlspaths: "/ping"
 
   slack:

--- a/falcosidekick/values.yaml
+++ b/falcosidekick/values.yaml
@@ -76,17 +76,25 @@ config:
   tlsserver:
     # -- if true TLS server will be deployed instead of HTTP
     deploy: false
-    # -- server certification file for TLS Server
+    # -- existing secret with server.crt, server.key and ca.crt files for TLS Server
+    existingSecret: ""
+    # -- server.crt file for TLS Server
+    servercrt: ""
+    # -- server certification file path for TLS Server
     certfile: "/etc/certs/server/server.crt"
-    # -- server key file for TLS Server
+    # -- server.key file for TLS Server
+    serverkey: ""
+    # -- server key file path for TLS Server
     keyfile: "/etc/certs/server/server.key"
     # -- if true mutual TLS server will be deployed instead of TLS, deploy also has to be true
     mutualtls: false
-    # --  CA certification file for client certification if mutualtls is true
+    # ca.crt file for client certification if mutualtls is true
+    cacrt: ""
+    # --  CA certification file path for client certification if mutualtls is true
     cacertfile: "/etc/certs/server/ca.crt"
     # -- port to serve http server serving selected endpoints
     notlsport: 2810
-    # -- a comma separated list of endpoints, if not empty, a separate http server will be deployed for the specified endpoints. Ping endpoint needs to be notls to be able to check the health of the pod.
+    # -- a comma separated list of endpoints. A separate http server will be deployed for the specified endpoints. Ping endpoint needs to be notls for Kubernetes to be able to check the health of the pod
     notlspaths: "/ping"
 
   slack:
@@ -924,19 +932,6 @@ extraVolumes: []
 extraVolumeMounts: []
 # - mountPath: /etc/certs/mtlscert.optional.tls
 #   name: optional-mtls-volume
-
-# -- Certificates for mutual TLS server
-certs:
-  # -- Existing secret containing the following key, crt and ca as well as the bundle pem.
-  existingSecret: ""
-  server:
-    # -- Server Key to authenticate with the clients
-    key: ""
-    # -- Server Certificate to authenticate with the clients
-    crt: ""
-  ca:
-    # -- CA certificate to validate the clients
-    crt: ""
 
 testConnection:
   # -- test connection nodeSelector field

--- a/falcosidekick/values.yaml
+++ b/falcosidekick/values.yaml
@@ -86,8 +86,8 @@ config:
     cacertfile: "/etc/certs/server/ca.crt"
     # -- port to serve http server serving selected endpoints
     notlsport: 2810
-    # -- a comma separated list of endpoints, if not empty, a separate http server will be deployed for the specified endpoints
-    notlspaths: ""
+    # -- a comma separated list of endpoints, if not empty, a separate http server will be deployed for the specified endpoints. Ping endpoint needs to be notls to be able to check the health of the pod.
+    notlspaths: "/ping"
 
   slack:
     # -- Slack Webhook URL (ex: <https://hooks.slack.com/services/XXXX/YYYY/ZZZZ>), if not `empty`, Slack output is *enabled*
@@ -924,6 +924,19 @@ extraVolumes: []
 extraVolumeMounts: []
 # - mountPath: /etc/certs/mtlscert.optional.tls
 #   name: optional-mtls-volume
+
+# -- Certificates for mutual TLS server
+certs:
+  # -- Existing secret containing the following key, crt and ca as well as the bundle pem.
+  existingSecret: ""
+  server:
+    # -- Server Key to authenticate with the clients
+    key: ""
+    # -- Server Certificate to authenticate with the clients
+    crt: ""
+  ca:
+    # -- CA certificate to validate the clients
+    crt: ""
 
 testConnection:
   # -- test connection nodeSelector field


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falcosidekick-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds the capability of loading certificates for mTLS communication dynamically via helm values. It's structured in a way to make it easier to deploy mTLS cryptographic material for falcosidekick http server when mTLS is enabled.

**Which issue(s) this PR fixes**:
 
N/A

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

Split of #546.

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Variables are documented in the README.md
