### PR TITLE
Add support for extra arguments for falcosidekick chart

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.7.7
+
+* Support extraArgs in the helm chart
+
 ## 0.7.6
 
 * Fix the behavior with the `AWS IRSA` with a new value `aws.config.useirsa`

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.28.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.7.6
+version: 0.7.7
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/README.md
+++ b/charts/falcosidekick/README.md
@@ -253,6 +253,7 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | config.elasticsearch.username | string | `""` | use this username to authenticate to Elasticsearch if the username is not empty |
 | config.existingSecret | string | `""` | Existing secret with configuration |
 | config.extraEnv | list | `[]` | Extra environment variables |
+| config.extraArgs | list | `[]` | Extra arguments for falcosidekick execution |
 | config.fission.checkcert | bool | `true` | check if ssl certificate of the output is valid |
 | config.fission.function | string | `""` | Name of Fission function, if not empty, Fission is enabled |
 | config.fission.minimumpriority | string | `""` | minimum priority of event to use this output, order is `emergency\|alert\|critical\|error\|warning\|notice\|informational\|debug or ""` |

--- a/charts/falcosidekick/templates/deployment.yaml
+++ b/charts/falcosidekick/templates/deployment.yaml
@@ -86,6 +86,10 @@ spec:
           securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
           {{- end }}
+          {{- if .Values.config.extraArgs }}
+          args:
+          {{ toYaml .Values.config.extraArgs | nindent 12 }}
+          {{- end }}
           envFrom:
             - secretRef:
                 {{- if .Values.config.existingSecret }}

--- a/charts/falcosidekick/values.yaml
+++ b/charts/falcosidekick/values.yaml
@@ -112,6 +112,8 @@ config:
   existingSecret: ""
   # -- Extra environment variables
   extraEnv: []
+  # -- Extra command-line arguments
+  extraArgs: []
   # -- DEBUG environment variable
   debug: false
   # -- a list of escaped comma separated custom fields to add to falco events, syntax is "key:value\,key:value"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind chart-release


**Any specific area of the project related to this PR?**
/area falcosidekick-chart


**What this PR does / why we need it**:
This PR add support for extra args for falcosidekick chart. This allows specifying a config file for falcosidekick for situations when relying on environment variables is not possible (e.g. settings which contain confidential values which are injected into a file).
This is useful when secrets are loaded into pods with [Hashicorp Vault's Agent sidecar injector](https://developer.hashicorp.com/vault/docs/platform/k8s/injector).

A possible usage in falco's values.yaml file is:
```
falcosidekick:
  enabled: true 
  config:
    extraArgs:
      - -c
      - /a/b/c/config.yaml
```
This loads the config.yaml file located at /a/b/c/config.yaml for falcosidekick.


**Which issue(s) this PR fixes**:
No issue is opened for this PR

**Special notes for your reviewer**:
I've bumped the falcosidekick chart version to 0.7.7 ~~and the falco chart to 3.8.3 (to update the referenced falcosidekick version).~~

**Checklist**
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
