### PR TITLE
Feature: Add mTLS certificate loading for Falco via Helm

### DIFF
--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v3.8.5
+
+* Add mTLS cryptographic material load via Helm for Falco
+
 ## v3.8.4
 
 * Upgrade Falco to 0.36.2: https://github.com/falcosecurity/falco/releases/tag/0.36.2

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 3.8.4
+version: 3.8.5
 appVersion: "0.36.2"
 description: Falco
 keywords:

--- a/charts/falco/README.md
+++ b/charts/falco/README.md
@@ -474,6 +474,37 @@ helm install falco \
   falcosecurity/falco
 ```
 
+## Enable http_output
+
+HTTP output enables Falco to send events through HTTP(S) via the following configuration:
+
+```shell
+helm install falco \
+  --set falco.http_output.enabled=true \
+  --set falco.http_output.url="http://some.url/some/path/" \
+  --set falco.json_output=true \
+  --set json_include_output_property=true
+  falcosecurity/falco
+```
+
+Additionaly, you can enable mTLS communication and load HTTP client cryptographic material via:
+
+```shell
+helm install falco \
+  --set falco.http_output.enabled=true \
+  --set falco.http_output.url="https://some.url/some/path/" \
+  --set falco.json_output=true \
+  --set json_include_output_property=true \
+  --set falco.http_output.mtls=true \
+  --set falco.http_output.client_cert="/etc/falco/certs/client/client.crt" \
+  --set falco.http_output.client_key="/etc/falco/certs/client/client.key" \
+  --set falco.http_output.ca_cert="/etc/falco/certs/client/ca.crt" \
+  --set-file certs.client.key="/path/to/client.key",certs.client.crt="/path/to/client.crt",certs.ca.crt="/path/to/cacert.crt" \
+  falcosecurity/falco
+```
+
+Or instead of directly setting the files via `--set-file`, mounting an existing volume with the `certs.existingClientSecret` value.
+
 ## Deploy Falcosidekick with Falco
 
 [`Falcosidekick`](https://github.com/falcosecurity/falcosidekick) can be installed with `Falco` by setting `--set falcosidekick.enabled=true`. This setting automatically configures all options of `Falco` for working with `Falcosidekick`.

--- a/charts/falco/templates/client-certs-secret.yaml
+++ b/charts/falco/templates/client-certs-secret.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.certs.client.key .Values.certs.client.crt .Values.certs.ca.crt }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "falco.fullname" . }}-client-certs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "falco.name" . }}
+    helm.sh/chart: {{ include "falco.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  {{ $key := .Values.certs.client.key }}
+  client.key: {{ $key | b64enc | quote }}
+  {{ $crt := .Values.certs.client.crt }}
+  client.crt: {{ $crt | b64enc | quote }}
+  falcoclient.pem: {{ print $key $crt | b64enc | quote }}
+  ca.crt: {{ .Values.certs.ca.crt | b64enc | quote }}
+  ca.pem: {{ .Values.certs.ca.crt | b64enc | quote }}
+{{- end }}

--- a/charts/falco/templates/client-certs-secret.yaml
+++ b/charts/falco/templates/client-certs-secret.yaml
@@ -5,10 +5,7 @@ metadata:
   name: {{ include "falco.fullname" . }}-client-certs
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "falco.name" . }}
-    helm.sh/chart: {{ include "falco.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "falco.labels" $ | nindent 4 }}
 type: Opaque
 data:
   {{ $key := .Values.certs.client.key }}

--- a/charts/falco/templates/pod-template.tpl
+++ b/charts/falco/templates/pod-template.tpl
@@ -201,6 +201,11 @@ spec:
           name: certs-volume
           readOnly: true
         {{- end }}
+        {{- if or .Values.certs.existingSecret (and .Values.certs.client.key .Values.certs.client.crt .Values.certs.ca.crt) }}
+        - mountPath: /etc/falco/certs/client
+          name: client-certs-volume
+          readOnly: true
+        {{- end }}
         {{- include "falco.unixSocketVolumeMount"  . | nindent 8 -}}
         {{- with .Values.mounts.volumeMounts }}
           {{- toYaml . | nindent 8 }}
@@ -333,6 +338,15 @@ spec:
         secretName: {{ .Values.certs.existingSecret }}
         {{- else }}
         secretName: {{ include "falco.fullname" . }}-certs
+        {{- end }}
+    {{- end }}
+    {{- if or .Values.certs.existingSecret (and .Values.certs.client.key .Values.certs.client.crt .Values.certs.ca.crt) }}
+    - name: client-certs-volume
+      secret:
+        {{- if .Values.certs.existingClientSecret }}
+        secretName: {{ .Values.certs.existingClientSecret }}
+        {{- else }}
+        secretName: {{ include "falco.fullname" . }}-client-certs
         {{- end }}
     {{- end }}
     {{- include "falco.unixSocketVolume" . | nindent 4 -}}

--- a/charts/falco/values.yaml
+++ b/charts/falco/values.yaml
@@ -313,6 +313,13 @@ certs:
   ca:
     # -- CA certificate used by gRPC, webserver and AuditSink validation.
     crt: ""
+  existingClientSecret: ""
+  client:
+    # -- Key used by http mTLS client.
+    key: ""
+    # -- Certificate used by http mTLS client.
+    crt: ""
+
 # -- Third party rules enabled for Falco. More info on the dedicated section in README.md file.
 customRules:
   {}
@@ -708,13 +715,13 @@ falco:
     ca_bundle: ""
     # -- Path to a folder that will be used as the CA certificate store. CA certificate need to be
     # stored as indivitual PEM files in this directory.
-    ca_path: "/etc/ssl/certs"
+    ca_path: "/etc/falco/certs/"
     # -- Tell Falco to use mTLS
     mtls: false
     # -- Path to the client cert.
-    client_cert: "/etc/ssl/certs/client.crt"
+    client_cert: "/etc/falco/certs/client/client.crt"
     # -- Path to the client key.
-    client_key: "/etc/ssl/certs/client.key"
+    client_key: "/etc/falco/certs/client/client.key"
     # -- Whether to echo server answers to stdout
     echo: false
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falco-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds the capability of loading certificates for mTLS communication dynamically via Helm values. It's structured in a way to make it easier to deploy mTLS cryptographic material for Falco http_output when mTLS is enabled.

**Which issue(s) this PR fixes**:
 
N/A

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

Substituting #549 

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Variables are documented in the README.md
