### PR TITLE
Upgrade falcosidekick chart to `v0.7.11` in falco chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ helm repo update
 
 ### Installing a chart
 
-Please refer to the instruction provided by the Chart you want to install. For installing Falco via Helm, the documentation is [here](https://github.com/falcosecurity/charts/tree/master/falco#adding-falcosecurity-repository).
+Please refer to the instruction provided by the Chart you want to install. For installing Falco via Helm, the documentation is [here](https://github.com/falcosecurity/charts/tree/master/charts/falco#adding-falcosecurity-repository).
 
 ## Contributing
 

--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v3.8.7
+
+*  Upgrade falcosidekick chart to `v0.7.11`.
+
 ## v3.8.6
 
 * no changes to the chart itself. Updated README.md and makefile.
@@ -124,7 +128,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 ## v2.5.4
 
-* Fix incorrect entry in v2.5.2 changelog 
+* Fix incorrect entry in v2.5.2 changelog
 
 ## v2.5.3
 

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 3.8.6
+version: 3.8.7
 appVersion: "0.36.2"
 description: Falco
 keywords:
@@ -19,6 +19,6 @@ maintainers:
     email: cncf-falco-dev@lists.cncf.io
 dependencies:
   - name: falcosidekick
-    version: "0.7.7"
+    version: "0.7.11"
     condition: falcosidekick.enabled
     repository: https://falcosecurity.github.io/charts


### PR DESCRIPTION

**What type of PR is this?**

/kind documentation

/kind feature

/kind chart-release


/area falco-chart


**What this PR does / why we need it**:

Upgrade falcosidekick chart to `v0.7.11` in falco chart

- [x] Chart Version bumped
- [x] CHANGELOG.md updated
