### PR TITLE
[falcosidekick] fix: remove duplicate component label

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.7.14
+
+- Fix duplicate component labels
+
 ## 0.7.13
 
 - Fix ServiceMonitor port name and selector labels

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.28.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.7.13
+version: 0.7.14
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/templates/_helpers.tpl
+++ b/charts/falcosidekick/templates/_helpers.tpl
@@ -63,7 +63,6 @@ Selector labels
 {{- define "falcosidekick.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "falcosidekick.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/component: core
 {{- end }}
 
 {{/*


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falcosidekick-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR removes the component label `core` from within the _helpers.tpl because it is set specific to each component within the corresponding templates - see https://github.com/falcosecurity/charts/pull/626#issuecomment-1953532813.

*This partly reverts #626.* 

To reproduce this issue run the following on #626:
```
git checkout 70efc03efebf52da11199271af161bf7ab0b656c
helm template falco .  --output-dir /dev/shm/70efc03
kubeconform -strict /dev/shm/70efc03/falcosidekick/templates/rbac.yaml
```

kubeconform will throw the following errors:
```
/dev/shm/70efc03/falcosidekick/templates/rbac.yaml - ServiceAccount falco-falcosidekick failed validation: error unmarshalling resource: error converting YAML to JSON: yaml: unmarshal errors:
  line 16: key "app.kubernetes.io/component" already set in map
/dev/shm/70efc03/falcosidekick/templates/rbac.yaml - RoleBinding falco-falcosidekick failed validation: error unmarshalling resource: error converting YAML to JSON: yaml: unmarshal errors:
  line 15: key "app.kubernetes.io/component" already set in map
/dev/shm/70efc03/falcosidekick/templates/rbac.yaml - Role falco-falcosidekick failed validation: error unmarshalling resource: error converting YAML to JSON: yaml: unmarshal errors:
  line 15: key "app.kubernetes.io/component" already set in map
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #626

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] CHANGELOG.md updated
