### PR TITLE
bump falcosidekick version in falco chart dependency

### DIFF
--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -3,7 +3,11 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
-##v4.2.3
+## v4.2.4
+
+* bump falcosidekick dependency version to install latest version through falco chart
+
+## v4.2.3
 
 * fix(falco/helpers): adjust formatting to be compatible with older helm versions
 

--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -5,7 +5,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 ## v4.2.4
 
-* bump falcosidekick dependency version to install latest version through falco chart
+* bump falcosidekick dependency version to v0.7.15 install latest version through falco chart
 
 ## v4.2.3
 

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 4.2.3
+version: 4.2.4
 appVersion: "0.37.1"
 description: Falco
 keywords:
@@ -19,7 +19,7 @@ maintainers:
     email: cncf-falco-dev@lists.cncf.io
 dependencies:
   - name: falcosidekick
-    version: "0.7.11"
+    version: "0.7.15"
     condition: falcosidekick.enabled
     repository: https://falcosecurity.github.io/charts
   - name: k8s-metacollector


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind chart-release

**Any specific area of the project related to this PR?**
/area falco-chart

**What this PR does / why we need it**:
Installing falcosidekick through the falco helm chart `falcosidekick.enabled: true` is not using the latest falcosidekick version. The installed version has a bug, which is fixed in this [PR](https://github.com/falcosecurity/charts/pull/626).

**Which issue(s) this PR fixes**:
[PR](https://github.com/falcosecurity/charts/pull/626)

**Special notes for your reviewer**:

**Checklist**
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
