### PR TITLE
The sidekick chart Prometheus rules can't be installed as is, leading to an error and preventing the resource to be created.

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,11 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+
+## 0.7.18
+
+- Fix PrometheusRule duplicate alert name
+
 ## 0.7.17
 
 - Fix the labels for the serviceMonitor

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.28.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.7.17
+version: 0.7.18
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/templates/prometheusrule.yaml
+++ b/charts/falcosidekick/templates/prometheusrule.yaml
@@ -77,7 +77,7 @@ spec:
         severity: critical
     {{- end }}
     {{- if .Values.prometheusRules.alerts.output.enabled }}
-    - alert: FalcoEmergencyEventsRateHigh
+    - alert: FalcoErrorOutputEventsRateHigh
       annotations:
         summary: Falcosidekick is experiencing high rate of errors for an output
         description: A high rate of errors are being detecting for an output


### PR DESCRIPTION
/kind bug

/kind chart-release

/area falcosidekick-chart


Prometheus does not accept duplicate rule name.

The chart Prometheus rules can't be installed as is, leading to an error and preventing the resource to be created.


- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
