### PR TITLE
feat: Add additionalProperties for falcosidekick service Monitor

### DIFF
--- a/charts/falco-exporter/CHANGELOG.md
+++ b/charts/falco-exporter/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to `falco-exporter` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.10.1
+
+* Enhanced the service Monitor to support additional Properties.
+
 ## v0.10.0
 
 * added ability to set the grafana folder annotation name

--- a/charts/falco-exporter/Chart.yaml
+++ b/charts/falco-exporter/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.10.0
+version: 0.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/falco-exporter/README.md
+++ b/charts/falco-exporter/README.md
@@ -70,7 +70,7 @@ helm install falco-exporter \
 
 ## Configuration
 
-The following table lists the main configurable parameters of the falco-exporter chart v0.10.0 and their default values. Please, refer to [values.yaml](./values.yaml) for the full list of configurable parameters.
+The following table lists the main configurable parameters of the falco-exporter chart v0.10.1 and their default values. Please, refer to [values.yaml](./values.yaml) for the full list of configurable parameters.
 
 ## Values
 
@@ -146,8 +146,9 @@ The following table lists the main configurable parameters of the falco-exporter
 | service.type | string | `"ClusterIP"` | type denotes the service type. Setting it to "ClusterIP" we ensure that are accessible from within the cluster. |
 | serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | serviceAccount is the configuration for the service account. |
 | serviceAccount.name | string | `""` | name is the name of the service account to use. If not set and create is true, a name is generated using the fullname template. If set and create is false, an already existing serviceAccount must be provided. |
-| serviceMonitor | object | `{"additionalLabels":{},"enabled":false,"interval":"","scrapeTimeout":""}` | serviceMonitor holds the configuration for the ServiceMonitor CRD. A ServiceMonitor is a custom resource definition (CRD) used to configure how Prometheus should discover and scrape metrics from the exporter service. |
+| serviceMonitor | object | `{"additionalLabels":{},"additionalProperties":{},"enabled":false,"interval":"","scrapeTimeout":""}` | serviceMonitor holds the configuration for the ServiceMonitor CRD. A ServiceMonitor is a custom resource definition (CRD) used to configure how Prometheus should discover and scrape metrics from the exporter service. |
 | serviceMonitor.additionalLabels | object | `{}` | additionalLabels specifies labels to be added on the Service Monitor. |
+| serviceMonitor.additionalProperties | object | `{}` | aditionalProperties allows setting additional properties on the endpoint such as relabelings, metricRelabelings etc. |
 | serviceMonitor.enabled | bool | `false` | enable the deployment of a Service Monitor for the Prometheus Operator. |
 | serviceMonitor.interval | string | `""` | interval specifies the time interval at which Prometheus should scrape metrics from the service. |
 | serviceMonitor.scrapeTimeout | string | `""` | scrapeTimeout determines the maximum time Prometheus should wait for a target to respond to a scrape request. If the target does not respond within the specified timeout, Prometheus considers the scrape as failed for that target. |

--- a/charts/falco-exporter/templates/servicemonitor.yaml
+++ b/charts/falco-exporter/templates/servicemonitor.yaml
@@ -18,6 +18,9 @@ spec:
     {{- if .Values.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- with .Values.serviceMonitor.additionalProperties }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "falco-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/falco-exporter/values.yaml
+++ b/charts/falco-exporter/values.yaml
@@ -170,7 +170,8 @@ serviceMonitor:
   # If the target does not respond within the specified timeout, Prometheus considers the scrape as failed for
   # that target.
   scrapeTimeout: ""
-
+    # -- aditionalProperties allows setting additional properties on the endpoint such as relabelings, metricRelabelings etc.
+  additionalProperties: {}
 # -- grafanaDashboard contains the configuration related to grafana dashboards.
 grafanaDashboard:
   # -- enabled specifies whether the dashboard should be deployed.

--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.7.18
+
+- Enhanced the service Monitor to support additional Properties.
+
 ## 0.7.17
 
 - Fix the labels for the serviceMonitor

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.28.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.7.17
+version: 0.7.18
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/README.md
+++ b/charts/falcosidekick/README.md
@@ -574,6 +574,7 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | service.port | int | `2801` | Service port |
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceMonitor.additionalLabels | object | `{}` | specify Additional labels to be added on the Service Monitor. |
+| serviceMonitor.additionalProperties | object | `{}` | aditionalProperties allows setting additional properties on the endpoint such as relabelings, metricRelabelings etc. |
 | serviceMonitor.enabled | bool | `false` | enable the deployment of a Service Monitor for the Prometheus Operator. |
 | serviceMonitor.interval | string | `""` | specify a user defined interval. When not specified Prometheus default interval is used. |
 | serviceMonitor.scrapeTimeout | string | `""` | specify a user defined scrape timeout. When not specified Prometheus default scrape timeout is used. |

--- a/charts/falcosidekick/templates/servicemonitor.yaml
+++ b/charts/falcosidekick/templates/servicemonitor.yaml
@@ -19,6 +19,9 @@ spec:
     {{- if .Values.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- with .Values.serviceMonitor.additionalProperties }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "falcosidekick.labels" . | nindent 6 }}

--- a/charts/falcosidekick/values.yaml
+++ b/charts/falcosidekick/values.yaml
@@ -58,6 +58,8 @@ serviceMonitor:
   interval: ""
   # -- specify a user defined scrape timeout. When not specified Prometheus default scrape timeout is used.
   scrapeTimeout: ""
+  # -- aditionalProperties allows setting additional properties on the endpoint such as relabelings, metricRelabelings etc.
+  additionalProperties: {}
 
 prometheusRules:
   # -- enable the creation of PrometheusRules for alerting


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area falco-chart

> /area falco-exporter-chart

/area falcosidekick-chart

> /area event-generator-chart

> /area k8s-metacollector

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
I've added the capability to the Falco-exporter charts to set additional properties within the Service Monitor, such as relabelings, metricRelabelings, etc.
I ran a Helm template and tested the Service Monitor in an OpenShift cluster.

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
