### PR TITLE
Fix existing client secret check

### DIFF
--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
+
+## v4.4.2
+
+* fix wrong check in pod template where `existingSecret` was used instead of `existingClientSecret`
+
 ## v4.4.1
 
 * bump k8s-metacollector dependency version to v0.1.1. See: https://github.com/falcosecurity/k8s-metacollector/releases

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 4.4.1
+version: 4.4.2
 appVersion: "0.38.0"
 description: Falco
 keywords:

--- a/charts/falco/README.md
+++ b/charts/falco/README.md
@@ -581,7 +581,7 @@ If you use a Proxy in your cluster, the requests between `Falco` and `Falcosidek
 
 ## Configuration
 
-The following table lists the main configurable parameters of the falco chart v4.4.1 and their default values. See [values.yaml](./values.yaml) for full list.
+The following table lists the main configurable parameters of the falco chart v4.4.2 and their default values. See [values.yaml](./values.yaml) for full list.
 
 ## Values
 

--- a/charts/falco/templates/pod-template.tpl
+++ b/charts/falco/templates/pod-template.tpl
@@ -323,7 +323,7 @@ spec:
         secretName: {{ include "falco.fullname" . }}-certs
         {{- end }}
     {{- end }}
-    {{- if or .Values.certs.existingSecret (and .Values.certs.client.key .Values.certs.client.crt .Values.certs.ca.crt) }}
+    {{- if or .Values.certs.existingClientSecret (and .Values.certs.client.key .Values.certs.client.crt .Values.certs.ca.crt) }}
     - name: client-certs-volume
       secret:
         {{- if .Values.certs.existingClientSecret }}


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-chart


**What this PR does / why we need it**:

This PR fixes a check in the falco pod template, which uses the `existingSecret` variable instead of `existingClientSecret` when deciding if client secrets are enabled.

The consequence was that the chart would not work correctly when defining `existingSecret` but not `existingClientSecret`: it would try to attach an unexisting configmap to falco pods

**Checklist**

- [ x ] Chart Version bumped
- [ x ] Variables are documented in the README.md
- [ x ] CHANGELOG.md updated
