### PR TITLE
Feat: add extra labeling capabilities for falco daemonset/deployment

### DIFF
--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v4.4.3
+
+* Added a `labels` field in the controller to provide extra labeling for the daemonset/deployment
+
 ## v4.4.2
 
 * fix wrong check in pod template where `existingSecret` was used instead of `existingClientSecret`

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 4.4.2
+version: 4.4.3
 appVersion: "0.38.0"
 description: Falco
 keywords:

--- a/charts/falco/README.md
+++ b/charts/falco/README.md
@@ -581,7 +581,7 @@ If you use a Proxy in your cluster, the requests between `Falco` and `Falcosidek
 
 ## Configuration
 
-The following table lists the main configurable parameters of the falco chart v4.4.2 and their default values. See [values.yaml](./values.yaml) for full list.
+The following table lists the main configurable parameters of the falco chart v4.4.3 and their default values. See [values.yaml](./values.yaml) for full list.
 
 ## Values
 
@@ -612,6 +612,7 @@ The following table lists the main configurable parameters of the falco chart v4
 | controller.daemonset.updateStrategy.type | string | `"RollingUpdate"` | Perform rolling updates by default in the DaemonSet agent ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/ |
 | controller.deployment.replicas | int | `1` | Number of replicas when installing Falco using a deployment. Change it if you really know what you are doing. For more info check the section on Plugins in the README.md file. |
 | controller.kind | string | `"daemonset"` |  |
+| controller.labels | object | `{}` | Extra labels to add to the daemonset or deployment |
 | customRules | object | `{}` | Third party rules enabled for Falco. More info on the dedicated section in README.md file. |
 | driver.ebpf | object | `{"bufSizePreset":4,"dropFailedExit":false,"hostNetwork":false,"leastPrivileged":false,"path":"${HOME}/.falco/falco-bpf.o"}` | Configuration section for ebpf driver. |
 | driver.ebpf.bufSizePreset | int | `4` | bufSizePreset determines the size of the shared space between Falco and its drivers. This shared space serves as a temporary storage for syscall events. |

--- a/charts/falco/templates/daemonset.yaml
+++ b/charts/falco/templates/daemonset.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "falco.namespace" . }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
+    {{- if .Values.controller.labels }}
+      {{- toYaml .Values.controller.labels | nindent 4 }}
+    {{- end }}
   {{- if .Values.controller.annotations }}
   annotations:
   {{ toYaml .Values.controller.annotations | nindent 4 }}

--- a/charts/falco/templates/deployment.yaml
+++ b/charts/falco/templates/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "falco.namespace" . }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
+    {{- if .Values.controller.labels }}
+      {{- toYaml .Values.controller.labels | nindent 4 }}
+    {{- end }}
   {{- if .Values.controller.annotations }}
   annotations:
   {{ toYaml .Values.controller.annotations | nindent 4 }}

--- a/charts/falco/values.yaml
+++ b/charts/falco/values.yaml
@@ -139,6 +139,8 @@ controller:
   kind: daemonset
   # Annotations to add to the daemonset or deployment
   annotations: {}
+  # -- Extra labels to add to the daemonset or deployment
+  labels: {}
   daemonset:
     updateStrategy:
       # You can also customize maxUnavailable or minReadySeconds if you


### PR DESCRIPTION

/kind feature

/kind chart-release

/area falco-chart

**What this PR does / why we need it**:

This PR adds an extra field: `controller.labels` which allows users to set extra labels for the Falco daemonset/deployment. 

- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] CHANGELOG.md updated
