### PR TITLE
Fixes #686

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.7.21
+
+- Fix the Falco Sidekick WEBUI_URL secret value.
+
 ## 0.7.20
 
 - Align Web UI service port from values.yaml file with Falco Sidekick WEBUI_URL secret value.

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.28.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.7.20
+version: 0.7.21
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/templates/secrets.yaml
+++ b/charts/falcosidekick/templates/secrets.yaml
@@ -445,7 +445,7 @@ data:
 
   # WebUI Output
   {{- if .Values.webui.enabled -}}
-  {{ $weburl := printf "http://%s-ui:%s" (include "falcosidekick.fullname" .) .Values.webui.service.port }}
+  {{ $weburl := printf "http://%s-ui:%d" (include "falcosidekick.fullname" .) (.Values.webui.service.port | int) }}
   WEBUI_URL: "{{ $weburl | b64enc }}"
   {{- end }}
 {{- end }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area falcosidekick-chart

**What this PR does / why we need it**:

Wrong WEBUI_URL value since #685.

Example:

```
# helm template -s templates/secrets.yaml . | yq '.data.WEBUI_URL|@base64d'
http://release-name-falcosidekick-ui:%!s(float64=2802)
```

Should be:

```
# helm template -s templates/secrets.yaml . | yq '.data.WEBUI_URL|@base64d'
http://release-name-falcosidekick-ui:2802
```

**Which issue(s) this PR fixes**:

Fixes #686

**Special notes for your reviewer**:

**Checklist**

- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
