### PR TITLE
chore(falcosidekick): upgrade redis-stack image to 7.2.0-v11

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.7.22
+
+- upgrade redis-stack image to 7.2.0-v11
+
 ## 0.7.21
 
 - Fix the Falco Sidekick WEBUI_URL secret value.

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.28.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.7.21
+version: 0.7.22
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/README.md
+++ b/charts/falcosidekick/README.md
@@ -610,7 +610,7 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | webui.redis.image.pullPolicy | string | `"IfNotPresent"` | The web UI image pull policy |
 | webui.redis.image.registry | string | `"docker.io"` | The web UI Redis image registry to pull from |
 | webui.redis.image.repository | string | `"redis/redis-stack"` | The web UI Redis image repository to pull from |
-| webui.redis.image.tag | string | `"6.2.6-v3"` | The web UI Redis image tag to pull from |
+| webui.redis.image.tag | string | `"7.2.0-v11"` | The web UI Redis image tag to pull from |
 | webui.redis.nodeSelector | object | `{}` | Web UI Redis nodeSelector field |
 | webui.redis.password | string | `""` | Set a password for Redis |
 | webui.redis.podAnnotations | object | `{}` | additions annotations on the pods |

--- a/charts/falcosidekick/values.yaml
+++ b/charts/falcosidekick/values.yaml
@@ -1116,7 +1116,7 @@ webui:
       # -- The web UI Redis image repository to pull from
       repository: redis/redis-stack
       # -- The web UI Redis image tag to pull from
-      tag: "6.2.6-v3"
+      tag: "7.2.0-v11"
       # -- The web UI image pull policy
       pullPolicy: IfNotPresent
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falcosidekick-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The default image of redis-stack has been released in February 2023 and is outdated.
This should be updated to a more recent tag (see https://hub.docker.com/r/redis/redis-stack/tags).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

-/-

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
