### PR TITLE
feat(falcosidekick): allow to set resources, securityContext and image overwrite for wait-redis initContainer

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.8.1
+
+- allow to set resources, securityContext and image overwrite for wait-redis initContainer
+
 ## 0.8.0
 
 - ugrade to Falcosidekick 2.29.0

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.29.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.8.0
+version: 0.8.1
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/README.md
+++ b/charts/falcosidekick/README.md
@@ -641,6 +641,12 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | webui.ingress.hosts | list | `[{"host":"falcosidekick-ui.local","paths":[{"path":"/"}]}]` | Web UI ingress hosts configuration |
 | webui.ingress.ingressClassName | string | `""` | ingress class name |
 | webui.ingress.tls | list | `[]` | Web UI ingress TLS configuration |
+| webui.initContainer | object | `{"image":{"registry":"docker.io","repository":"busybox","tag":1.31},"resources":{},"securityContext":{}}` | Web UI wait-redis initContainer |
+| webui.initContainer.image.registry | string | `"docker.io"` | wait-redis initContainer image registry to pull from |
+| webui.initContainer.image.repository | string | `"busybox"` | wait-redis initContainer image repository to pull from |
+| webui.initContainer.image.tag | float | `1.31` | wait-redis initContainer image tag to pull |
+| webui.initContainer.resources | object | `{}` | wait-redis initContainer resources |
+| webui.initContainer.securityContext | object | `{}` | wait-redis initContainer securityContext |
 | webui.loglevel | string | `"info"` | Log level ("debug", "info", "warning", "error") |
 | webui.nodeSelector | object | `{}` | Web UI nodeSelector field |
 | webui.podAnnotations | object | `{}` | additions annotations on the pods web UI |

--- a/charts/falcosidekick/templates/deployment-ui.yaml
+++ b/charts/falcosidekick/templates/deployment-ui.yaml
@@ -58,8 +58,16 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-redis
-          image: busybox:1.31
+          image: "{{ .Values.webui.initContainer.image.registry }}/{{ .Values.webui.initContainer.image.repository }}:{{ .Values.webui.initContainer.image.tag }}"
           command: ['sh', '-c', 'echo -e "Checking for the availability of the Redis Server"; while ! nc -z {{ include "falcosidekick.fullname" . }}-ui-redis 6379; do sleep 1; done; echo -e "Redis Server has started";']
+          {{- if .Values.webui.initContainer.resources }}
+          resources:
+          {{- toYaml .Values.webui.initContainer.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.webui.initContainer.securityContext }}
+          securityContext:
+          {{- toYaml .Values.webui.initContainer.securityContext | nindent 12}}
+          {{- end }}
       containers:
         - name: {{ .Chart.Name }}-ui
           image: "{{ .Values.webui.image.registry }}/{{ .Values.webui.image.repository }}:{{ .Values.webui.image.tag }}"

--- a/charts/falcosidekick/values.yaml
+++ b/charts/falcosidekick/values.yaml
@@ -1137,6 +1137,20 @@ webui:
     # -- The web UI image pull policy
     pullPolicy: IfNotPresent
 
+  # -- Web UI wait-redis initContainer
+  initContainer:
+    image:
+      # -- wait-redis initContainer image registry to pull from
+      registry: docker.io
+      # -- wait-redis initContainer image repository to pull from
+      repository: busybox
+      # -- wait-redis initContainer image tag to pull
+      tag: 1.31
+    # -- wait-redis initContainer securityContext
+    securityContext: {}
+    # -- wait-redis initContainer resources
+    resources: {}
+
   # -- Web UI pod securityContext
   podSecurityContext:
     runAsUser: 1234


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

/kind chart-release

**Any specific area of the project related to this PR?**

/area falcosidekick-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
If someone wants to define resource limits or a security context for the wait-redis init container, this change can be useful.
The default values are empty and therefore this change won't break any existing setup.
It also allows the user to update or replace the busybox image.

Setting resource limits and security contexts are forced in many organizations, e.g. by using checkov and gatekeeper policies.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
