### PR TITLE
Fix redis-availability check in UI

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.8.2
+
+- Fix redis-availability check of the UI init-container in case externalRedis is enabled
+
 ## 0.8.1
 
 - allow to set resources, securityContext and image overwrite for wait-redis initContainer

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.29.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.8.1
+version: 0.8.2
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/templates/deployment-ui.yaml
+++ b/charts/falcosidekick/templates/deployment-ui.yaml
@@ -59,7 +59,11 @@ spec:
       initContainers:
         - name: wait-redis
           image: "{{ .Values.webui.initContainer.image.registry }}/{{ .Values.webui.initContainer.image.repository }}:{{ .Values.webui.initContainer.image.tag }}"
+          {{- if .Values.webui.redis.enabled }}
           command: ['sh', '-c', 'echo -e "Checking for the availability of the Redis Server"; while ! nc -z {{ include "falcosidekick.fullname" . }}-ui-redis 6379; do sleep 1; done; echo -e "Redis Server has started";']
+          {{- else if .Values.webui.externalRedis.enabled }}
+          command: ['sh', '-c', 'echo -e "Checking for the availability of the Redis Server"; while ! nc -z {{ required "External Redis is enabled. Please set the URL to the database." .Values.webui.externalRedis.url }} {{ .Values.webui.externalRedis.port | default "6379" }}; do sleep 1; done; echo -e "Redis Server has started";']
+          {{- end}}
           {{- if .Values.webui.initContainer.resources }}
           resources:
           {{- toYaml .Values.webui.initContainer.resources | nindent 12 }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind chart-release

**Any specific area of the project related to this PR?**
/area falco-chart
/area falcosidekick-chart

**Which issue(s) this PR fixes**:
It fixes the redis-availability check of the UI init-container in case external-redis is enabled. It was using the hard-coded value used when you would not use an exernal-redis.

I also upgraded the chart-version of the sidekick and flaco to get the fix also into the falco chart. It would certainly support the use I have - but I don't know if bumping two versions at once is something you do. Let me know.

- [x] Chart Version bumped
- [x] CHANGELOG.md updated
