### PR TITLE
Bump falco-sidekick dependency version to include redis UI check

### DIFF
--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v4.6.1
+
+* bump falcosidekick dependency to v0.8.2 (fixes bug when using externalRedis in UI)
+
 ## v4.6.0
 
 * feat(falco): add support for Falco metrics

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 4.6.0
+version: 4.6.1
 appVersion: "0.38.1"
 description: Falco
 keywords:
@@ -19,7 +19,7 @@ maintainers:
     email: cncf-falco-dev@lists.cncf.io
 dependencies:
   - name: falcosidekick
-    version: "0.8.0"
+    version: "0.8.2"
     condition: falcosidekick.enabled
     repository: https://falcosecurity.github.io/charts
   - name: k8s-metacollector


### PR DESCRIPTION
**What type of PR is this?**
/kind chart-release

**Any specific area of the project related to this PR?**
/area falco-chart

**What this PR does / why we need it**:
Updates the sidekick dependency on falco so that the fix of redis-external is included.

- [x] Chart Version bumped
- [x] CHANGELOG.md updated
