### PR TITLE
Fix running of k8saudit actions

### DIFF
--- a/charts/event-generator/CHANGELOG.md
+++ b/charts/event-generator/CHANGELOG.md
@@ -4,6 +4,10 @@
 This file documents all notable changes to `event-generator` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.3.4
+
+* Pass `--all` flag to event-generator binary to allow disabled rules to run, e.g. the k8saudit ruleset.
+
 ## v0.3.3
 
 * Update README.md.

--- a/charts/event-generator/Chart.yaml
+++ b/charts/event-generator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/event-generator/README.md
+++ b/charts/event-generator/README.md
@@ -117,7 +117,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following table lists the main configurable parameters of the event-generator chart v0.3.3 and their default values. See `values.yaml` for full list.
+The following table lists the main configurable parameters of the event-generator chart v0.3.4 and their default values. See `values.yaml` for full list.
 
 ## Values
 

--- a/charts/event-generator/templates/pod-template.tpl
+++ b/charts/event-generator/templates/pod-template.tpl
@@ -23,6 +23,7 @@ spec:
       command: 
         - /bin/event-generator 
         - {{ .Values.config.command }}
+        - --all
         {{- if .Values.config.actions }}
         - {{ .Values.config.actions }}
         {{- end }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind chart-release

/area event-generator-chart

**What this PR does / why we need it**:

Currently users who follow the [example config given here](https://github.com/falcosecurity/charts/blob/ba95f4cbf29a66727535c9460aa8b4f6a778b1f1/charts/event-generator/README.md?plain=1#L85) will see event-generator fail to start.

That's because the rules that match that regexp will only run when the `--all` [flag is provided](https://github.com/falcosecurity/event-generator/blob/7b0dab5d35e270084e84f2ba2156ae385feea3b6/docs/event-generator_run.md?plain=1#L25) because they are [marked as disabled](https://github.com/falcosecurity/event-generator/blob/main/events/k8saudit/yaml_disabled.go).

**Which issue(s) this PR fixes**:
* https://github.com/falcosecurity/charts/issues/723
* https://github.com/falcosecurity/event-generator/issues/212

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

This is my first contribution in Falcosecurity, please let me know if there is more I can do to make this as smooth as possible for review/acceptance.

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
