### PR TITLE
fix(falcosidekick): add support for custom service type for webui redis in Helm chart

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,9 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.8.4
+- Fix falcosidekick chart ignoring custom service type for webui redis
+
 ## 0.8.3
 
 - Add a condition to create the secrets for the redis only if the webui is deployed

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.29.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.8.3
+version: 0.8.4
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/templates/service-ui.yaml
+++ b/charts/falcosidekick/templates/service-ui.yaml
@@ -46,7 +46,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.webui.redis.service.type }}
   ports:
     - port: {{ .Values.webui.redis.service.port }}
       targetPort: {{ .Values.webui.redis.service.targetPort }}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falcosidekick-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes an issue in the Helm chart where the WebUI Redis service type was hardcoded to `ClusterIP`, ignoring the user-configured value under `webui.redis.service.type`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] CHANGELOG.md updated
