### PR TITLE
use redis-cli for the initContainer check

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,12 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.8.6
+
+- Use of `redis-cli` by the initContainer of Falcosidekick-UI to wait til the redis is up and running
+- Add the possibility to override the default redis server settings
+- Allow to set up a password to use with an external redis
+
 ## 0.8.5
 
 - Fix an issue with the by default missing custom CA cert

--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -10,6 +10,7 @@ Before release 0.1.20, the helm chart can be found in `falcosidekick` [repositor
 - Use of `redis-cli` by the initContainer of Falcosidekick-UI to wait til the redis is up and running
 - Add the possibility to override the default redis server settings
 - Allow to set up a password to use with an external redis
+- Fix wrong value used for `OTLP_TRACES_PROTOCOL` env var
 
 ## 0.8.5
 

--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -11,6 +11,7 @@ Before release 0.1.20, the helm chart can be found in `falcosidekick` [repositor
 - Add the possibility to override the default redis server settings
 - Allow to set up a password to use with an external redis
 - Fix wrong value used for `OTLP_TRACES_PROTOCOL` env var
+- Used names for the priorities in the prometheus rules
 
 ## 0.8.5
 

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.29.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.8.5
+version: 0.8.6
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/README.md
+++ b/charts/falcosidekick/README.md
@@ -630,6 +630,7 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | webui.enabled | bool | `false` | enable Falcosidekick-UI |
 | webui.existingSecret | string | `""` | Existing secret with configuration |
 | webui.externalRedis.enabled | bool | `false` | Enable or disable the usage of an external Redis. Is mutually exclusive with webui.redis.enabled. |
+| webui.externalRedis.password | string | `""` | Set the password of the external Redis |
 | webui.externalRedis.port | int | `6379` | The port of the external Redis database with RediSearch > v2 |
 | webui.externalRedis.url | string | `""` | The URL of the external Redis database with RediSearch > v2 |
 | webui.image.pullPolicy | string | `"IfNotPresent"` | The web UI image pull policy |
@@ -641,10 +642,10 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | webui.ingress.hosts | list | `[{"host":"falcosidekick-ui.local","paths":[{"path":"/"}]}]` | Web UI ingress hosts configuration |
 | webui.ingress.ingressClassName | string | `""` | ingress class name |
 | webui.ingress.tls | list | `[]` | Web UI ingress TLS configuration |
-| webui.initContainer | object | `{"image":{"registry":"docker.io","repository":"busybox","tag":1.31},"resources":{},"securityContext":{}}` | Web UI wait-redis initContainer |
+| webui.initContainer | object | `{"image":{"registry":"docker.io","repository":"redis/redis-stack","tag":"7.2.0-v11"},"resources":{},"securityContext":{}}` | Web UI wait-redis initContainer |
 | webui.initContainer.image.registry | string | `"docker.io"` | wait-redis initContainer image registry to pull from |
-| webui.initContainer.image.repository | string | `"busybox"` | wait-redis initContainer image repository to pull from |
-| webui.initContainer.image.tag | float | `1.31` | wait-redis initContainer image tag to pull |
+| webui.initContainer.image.repository | string | `"redis/redis-stack"` | wait-redis initContainer image repository to pull from |
+| webui.initContainer.image.tag | string | `"7.2.0-v11"` | wait-redis initContainer image tag to pull |
 | webui.initContainer.resources | object | `{}` | wait-redis initContainer resources |
 | webui.initContainer.securityContext | object | `{}` | wait-redis initContainer securityContext |
 | webui.loglevel | string | `"info"` | Log level ("debug", "info", "warning", "error") |
@@ -655,6 +656,7 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | webui.priorityClassName | string | `""` | Name of the priority class to be used by the Web UI pods, priority class needs to be created beforehand |
 | webui.redis.affinity | object | `{}` | Affinity for the Web UI Redis pods |
 | webui.redis.customAnnotations | object | `{}` | custom annotations to add to all resources |
+| webui.redis.customConfig | object | `{}` | List of Custom config overrides for Redis |
 | webui.redis.customLabels | object | `{}` | custom labels to add to all resources |
 | webui.redis.enabled | bool | `true` | Is mutually exclusive with webui.externalRedis.enabled |
 | webui.redis.existingSecret | string | `""` | Existing secret with configuration |

--- a/charts/falcosidekick/templates/configmap-ui.yaml
+++ b/charts/falcosidekick/templates/configmap-ui.yaml
@@ -1,0 +1,46 @@
+{{- if and (.Values.webui.enabled) (.Values.webui.redis.enabled) -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "falcosidekick.fullname" . }}-ui-redis
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "falcosidekick.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ui-redis
+data:
+  {{- if .Values.webui.redis.customConfig -}}
+  redis-stack.config: |-
+    {{ range .Values.webui.redis.customConfig }}
+    {{- . }}
+    {{ end -}}
+  {{- end }}
+  ping-redis.sh: |-
+    #!/bin/bash
+    for i in {1..10};
+    do
+      response=$(
+        timeout -s 3 30 \
+        redis-cli \
+          {{- if .Values.webui.redis.enabled }}
+          -h {{ include "falcosidekick.fullname" . }}-ui-redis -p 6379 \
+          {{- if .Values.webui.redis.password }}
+          -a ${REDIS_PASSWORD} \
+          {{- end }}
+          {{- end }}
+          {{- if .Values.webui.externalRedis.enabled }}
+          -h {{ .Values.webui.externalRedis.url }} \
+          -p {{ .Values.webui.externalRedis.port }} \
+          {{- if .Values.webui.externalRedis.password }}
+          -a ${REDIS_PASSWORD} \
+          {{- end }}
+          {{- end }}
+          ping
+        )
+      if [ "$response" = "PONG" ]; then
+        exit 0
+      fi
+      sleep 3
+    done
+    exit 1
+{{- end }}

--- a/charts/falcosidekick/templates/deployment-ui.yaml
+++ b/charts/falcosidekick/templates/deployment-ui.yaml
@@ -59,19 +59,29 @@ spec:
       initContainers:
         - name: wait-redis
           image: "{{ .Values.webui.initContainer.image.registry }}/{{ .Values.webui.initContainer.image.repository }}:{{ .Values.webui.initContainer.image.tag }}"
-          {{- if .Values.webui.redis.enabled }}
-          command: ['sh', '-c', 'echo -e "Checking for the availability of the Redis Server"; while ! nc -z {{ include "falcosidekick.fullname" . }}-ui-redis 6379; do sleep 1; done; echo -e "Redis Server has started";']
-          {{- else if .Values.webui.externalRedis.enabled }}
-          command: ['sh', '-c', 'echo -e "Checking for the availability of the Redis Server"; while ! nc -z {{ required "External Redis is enabled. Please set the URL to the database." .Values.webui.externalRedis.url }} {{ .Values.webui.externalRedis.port | default "6379" }}; do sleep 1; done; echo -e "Redis Server has started";']
-          {{- end}}
+          command:
+            - sh
+            - -c
+            - /scripts/ping-redis.sh
           {{- if .Values.webui.initContainer.resources }}
           resources:
           {{- toYaml .Values.webui.initContainer.resources | nindent 12 }}
           {{- end }}
           {{- if .Values.webui.initContainer.securityContext }}
-          securityContext:
+          securityContext:{{ include "falcosidekick.fullname" . }}-ui-redis
           {{- toYaml .Values.webui.initContainer.securityContext | nindent 12}}
           {{- end }}
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts/ping-redis.sh
+              subPath: ping-redis.sh
+          envFrom:
+            - secretRef:
+                name: {{ include "falcosidekick.fullname" . }}-ui
+            {{- if .Values.webui.existingSecret }}
+            - secretRef:
+                name: {{ .Values.webui.existingSecret }}
+            {{- end }}
       containers:
         - name: {{ .Chart.Name }}-ui
           image: "{{ .Values.webui.image.registry }}/{{ .Values.webui.image.repository }}:{{ .Values.webui.image.tag }}"
@@ -138,6 +148,14 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        - name: scripts
+          configMap:
+            name: {{ include "falcosidekick.fullname" . }}-ui-redis
+            defaultMode: 0555
+            items:
+              - key: ping-redis.sh
+                path: ping-redis.sh
 {{- if .Values.webui.redis.enabled }}
 ---
 apiVersion: apps/v1
@@ -220,10 +238,17 @@ spec:
           securityContext:
           {{- toYaml .Values.webui.redis.securityContext | nindent 12 }}
           {{- end }}
-          {{- if .Values.webui.redis.storageEnabled }}
+          {{- if or (.Values.webui.redis.storageEnabled) (.Values.webui.redis.customConfig) }}
           volumeMounts:
+          {{- if .Values.webui.redis.storageEnabled }}
           - name: {{ include "falcosidekick.fullname" . }}-ui-redis-data
             mountPath: /data
+          {{- end }}
+          {{- if .Values.webui.redis.customConfig }}
+          - name: config
+            mountPath: /redis-stack.config
+            subPath: redis-stack.config
+          {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.webui.redis.resources | nindent 12 }}
@@ -239,6 +264,16 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{ if .Values.webui.redis.customConfig }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "falcosidekick.fullname" . }}-ui-redis
+            defaultMode: 0444
+            items:
+              - key: redis-stack.config
+                path: redis-stack.config
+      {{ end }}
   {{- if .Values.webui.redis.storageEnabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/falcosidekick/templates/prometheusrule.yaml
+++ b/charts/falcosidekick/templates/prometheusrule.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         summary: Falco is experiencing high rate of warning events
         description: A high rate of warning events are being detected by Falco
-      expr: rate(falco_events{priority="4"}[{{ .Values.prometheusRules.alerts.warning.rate_interval }}]) > {{ .Values.prometheusRules.alerts.warning.threshold }}
+      expr: rate(falco_events{priority="Warning"}[{{ .Values.prometheusRules.alerts.warning.rate_interval }}]) > {{ .Values.prometheusRules.alerts.warning.threshold }}
       for: 15m
       labels:
         severity: warning
@@ -48,7 +48,7 @@ spec:
       annotations:
         summary: Falco is experiencing high rate of error events
         description: A high rate of error events are being detected by Falco
-      expr: rate(falco_events{priority="3"}[{{ .Values.prometheusRules.alerts.error.rate_interval }}]) > {{ .Values.prometheusRules.alerts.error.threshold }}
+      expr: rate(falco_events{priority="Error"}[{{ .Values.prometheusRules.alerts.error.rate_interval }}]) > {{ .Values.prometheusRules.alerts.error.threshold }}
       for: 15m
       labels:
         severity: warning
@@ -58,7 +58,7 @@ spec:
       annotations:
         summary: Falco is experiencing high rate of critical events
         description: A high rate of critical events are being detected by Falco
-      expr: rate(falco_events{priority="2"}[{{ .Values.prometheusRules.alerts.critical.rate_interval }}]) > {{ .Values.prometheusRules.alerts.critical.threshold }}
+      expr: rate(falco_events{priority="Critical"}[{{ .Values.prometheusRules.alerts.critical.rate_interval }}]) > {{ .Values.prometheusRules.alerts.critical.threshold }}
       for: 15m
       labels:
         severity: critical
@@ -68,7 +68,7 @@ spec:
       annotations:
         summary: Falco is experiencing high rate of alert events
         description: A high rate of alert events are being detected by Falco
-      expr: rate(falco_events{priority="1"}[{{ .Values.prometheusRules.alerts.alert.rate_interval }}]) > {{ .Values.prometheusRules.alerts.alert.threshold }}
+      expr: rate(falco_events{priority="Alert"}[{{ .Values.prometheusRules.alerts.alert.rate_interval }}]) > {{ .Values.prometheusRules.alerts.alert.threshold }}
       for: 5m
       labels:
         severity: critical
@@ -78,7 +78,7 @@ spec:
       annotations:
         summary: Falco is experiencing high rate of emergency events
         description: A high rate of emergency events are being detected by Falco
-      expr: rate(falco_events{priority="0"}[{{ .Values.prometheusRules.alerts.emergency.rate_interval }}]) > {{ .Values.prometheusRules.alerts.emergency.threshold }}
+      expr: rate(falco_events{priority="Emergency"}[{{ .Values.prometheusRules.alerts.emergency.rate_interval }}]) > {{ .Values.prometheusRules.alerts.emergency.threshold }}
       for: 1m
       labels:
         severity: critical

--- a/charts/falcosidekick/templates/secrets-ui.yaml
+++ b/charts/falcosidekick/templates/secrets-ui.yaml
@@ -42,8 +42,12 @@ metadata:
     {{- end }}
 type: Opaque
 data:
-  {{- if .Values.webui.redis.password }}
+  {{- if and .Values.webui.redis.enabled .Values.webui.redis.password }}
   REDIS_ARGS: "{{ printf "--requirepass %s" .Values.webui.redis.password | b64enc}}"
+  REDIS_PASSWORD: "{{ .Values.webui.redis.password | b64enc }}"
+  {{-  end }}
+  {{- if and .Values.webui.externalRedis.password .Values.webui.externalRedis.password }}
+  REDIS_PASSWORD: "{{ .Values.webui.externalRedis.password| b64enc }}"
   {{-  end }}
 {{- end }}
 {{- end }}

--- a/charts/falcosidekick/templates/secrets.yaml
+++ b/charts/falcosidekick/templates/secrets.yaml
@@ -463,7 +463,7 @@ data:
 
   # OTLP Traces
   OTLP_TRACES_ENDPOINT: "{{ .Values.config.otlp.traces.endpoint | b64enc}}"
-  OTLP_TRACES_PROTOCOL: "{{ .Values.config.otlp.traces.endpoint | b64enc}}"
+  OTLP_TRACES_PROTOCOL: "{{ .Values.config.otlp.traces.protocol | b64enc}}"
   OTLP_TRACES_TIMEOUT: "{{ .Values.config.otlp.traces.timeout | toString | b64enc}}"
   OTLP_TRACES_HEADERS: "{{ .Values.config.otlp.traces.headers | b64enc}}"
   OTLP_TRACES_SYNCED: "{{ .Values.config.otlp.traces.synced | printf "%t" | b64enc}}"

--- a/charts/falcosidekick/templates/service-ui.yaml
+++ b/charts/falcosidekick/templates/service-ui.yaml
@@ -22,9 +22,9 @@ spec:
   type: {{ .Values.webui.service.type }}
   ports:
     - port: {{ .Values.webui.service.port }}
-      {{ if eq .Values.webui.service.type "NodePort" }}
+      {{- if eq .Values.webui.service.type "NodePort" }}
       nodePort: {{ .Values.webui.service.nodePort }}
-      {{ end }}   
+      {{- end }}   
       targetPort: {{ .Values.webui.service.targetPort }}
       protocol: TCP
       name: http

--- a/charts/falcosidekick/values.yaml
+++ b/charts/falcosidekick/values.yaml
@@ -1143,9 +1143,9 @@ webui:
       # -- wait-redis initContainer image registry to pull from
       registry: docker.io
       # -- wait-redis initContainer image repository to pull from
-      repository: busybox
+      repository: redis/redis-stack
       # -- wait-redis initContainer image tag to pull
-      tag: 1.31
+      tag: "7.2.0-v11"
     # -- wait-redis initContainer securityContext
     securityContext: {}
     # -- wait-redis initContainer resources
@@ -1222,6 +1222,8 @@ webui:
     enabled: false
     # -- The URL of the external Redis database with RediSearch > v2
     url: ""
+    # -- Set the password of the external Redis
+    password: ""
     # --  The port of the external Redis database with RediSearch > v2
     port: 6379
   redis:
@@ -1236,6 +1238,11 @@ webui:
       tag: "7.2.0-v11"
       # -- The web UI image pull policy
       pullPolicy: IfNotPresent
+
+    # -- List of Custom config overrides for Redis
+    customConfig: {}
+      # - maxmemory-policy allkeys-lfu
+      # - maxmemory 4096mb
 
     # -- Existing secret with configuration
     existingSecret: ""


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area falco-chart

> /area falco-exporter-chart

/area falcosidekick-chart

> /area event-generator-chart

> /area k8s-metacollector

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

- Use of `redis-cli` by the initContainer of Falcosidekick-UI to wait til the redis is up and running
- Add the possibility to override the default redis server settings
- Allow to set up a password to use with an external redis

**Which issue(s) this PR fixes**:

#732 
https://github.com/falcosecurity/falcosidekick-ui/issues/140

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
