### PR TITLE
Fix setting of `OTLP_TRACES_PROTOCOL` to `config.otlp.traces.protocol`

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.8.6
+
+- Fix setting of `OTLP_TRACES_PROTOCOL` to `config.otlp.traces.protocol`
+
 ## 0.8.5
 
 - Fix an issue with the by default missing custom CA cert

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.29.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.8.5
+version: 0.8.6
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/templates/secrets.yaml
+++ b/charts/falcosidekick/templates/secrets.yaml
@@ -463,7 +463,7 @@ data:
 
   # OTLP Traces
   OTLP_TRACES_ENDPOINT: "{{ .Values.config.otlp.traces.endpoint | b64enc}}"
-  OTLP_TRACES_PROTOCOL: "{{ .Values.config.otlp.traces.endpoint | b64enc}}"
+  OTLP_TRACES_PROTOCOL: "{{ .Values.config.otlp.traces.protocol | b64enc}}"
   OTLP_TRACES_TIMEOUT: "{{ .Values.config.otlp.traces.timeout | toString | b64enc}}"
   OTLP_TRACES_HEADERS: "{{ .Values.config.otlp.traces.headers | b64enc}}"
   OTLP_TRACES_SYNCED: "{{ .Values.config.otlp.traces.synced | printf "%t" | b64enc}}"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area falcosidekick-chart

**What this PR does / why we need it**:

Aligns the config value `config.otlp.traces.protocol` with the environment variable used by Falco Sidekick.

**Which issue(s) this PR fixes**:

Fixes #741

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
