### PR TITLE
fix(falcosidekick): securityContext for webui initContainer

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.8.7
+
+- Fix securityContext for webui initContainer
+
 ## 0.8.6
 
 - Use of `redis-cli` by the initContainer of Falcosidekick-UI to wait til the redis is up and running

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.29.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.8.6
+version: 0.8.7
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/templates/deployment-ui.yaml
+++ b/charts/falcosidekick/templates/deployment-ui.yaml
@@ -68,7 +68,7 @@ spec:
           {{- toYaml .Values.webui.initContainer.resources | nindent 12 }}
           {{- end }}
           {{- if .Values.webui.initContainer.securityContext }}
-          securityContext:{{ include "falcosidekick.fullname" . }}-ui-redis
+          securityContext:
           {{- toYaml .Values.webui.initContainer.securityContext | nindent 12}}
           {{- end }}
           volumeMounts:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falcosidekick-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

With https://github.com/falcosecurity/charts/commit/15dfc64bfdf0260f17a4a166341a503291fa3e15 the securityContext for the webui initContainer became invalid by adding `{{ include "falcosidekick.fullname" . }}-ui-redis`:

```
templates/deployment-ui.yaml: error converting YAML to JSON: yaml: line 59: could not find expected ': 
```

See https://github.com/falcosecurity/charts/blob/falcosidekick-0.8.6/charts/falcosidekick/templates/deployment-ui.yaml#L71.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] CHANGELOG.md updated
