### PR TITLE
fix(falcosidekick): customConfig template fix for webui redis

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.8.8
+
+- Fix customConfig templat for webui redis
+
 ## 0.8.7
 
 - Fix securityContext for webui initContainer

--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -7,7 +7,7 @@ Before release 0.1.20, the helm chart can be found in `falcosidekick` [repositor
 
 ## 0.8.8
 
-- Fix customConfig templat for webui redis
+- Fix customConfig template for webui redis
 
 ## 0.8.7
 

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.29.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.8.7
+version: 0.8.8
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/templates/configmap-ui.yaml
+++ b/charts/falcosidekick/templates/configmap-ui.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "falcosidekick.labels" . | nindent 4 }}
     app.kubernetes.io/component: ui-redis
 data:
-  {{- if .Values.webui.redis.customConfig -}}
+  {{- if .Values.webui.redis.customConfig }}
   redis-stack.config: |-
     {{ range .Values.webui.redis.customConfig }}
     {{- . }}


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

/kind chart-release

**Any specific area of the project related to this PR?**

/area falcosidekick-chart

**What this PR does / why we need it**:

Currently defining `falcosidekick.webui.redis.customConfig`in `values.yaml` results in templating error:
```
Error: YAML parse error on falco/charts/falco/charts/falcosidekick/templates/configmap-ui.yaml: error converting YAML to JSON: yaml: line 17: 
did not find expected key
```
Using `--debug` switch shows us that one line is unnecessary suppressed (the key `data` is joined with `redis-stack.config`):
```yaml
data:redis-stack.config: |-
    maxmemory-policy allkeys-lfu
    maxmemory 4096mb
``` 
Tested with `values.yaml`:
```yaml
falcosidekick:
  webui:
    redis:
      customConfig: 
        - maxmemory-policy allkeys-lfu
        - maxmemory 4096mb
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**

- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] CHANGELOG.md updated
