### PR TITLE
fix(falcosidekick): customConfig mount path fix for webui redis

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.8.9
+
+- Fix customConfig mount path for webui redis
+
 ## 0.8.8
 
 - Fix customConfig template for webui redis

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.29.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.8.8
+version: 0.8.9
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/templates/configmap-ui.yaml
+++ b/charts/falcosidekick/templates/configmap-ui.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: ui-redis
 data:
   {{- if .Values.webui.redis.customConfig }}
-  redis-stack.config: |-
+  redis-stack.conf: |-
     {{ range .Values.webui.redis.customConfig }}
     {{- . }}
     {{ end -}}

--- a/charts/falcosidekick/templates/deployment-ui.yaml
+++ b/charts/falcosidekick/templates/deployment-ui.yaml
@@ -246,8 +246,8 @@ spec:
           {{- end }}
           {{- if .Values.webui.redis.customConfig }}
           - name: config
-            mountPath: /redis-stack.config
-            subPath: redis-stack.config
+            mountPath: /redis-stack.conf
+            subPath: redis-stack.conf
           {{- end }}
           {{- end }}
           resources:
@@ -271,8 +271,8 @@ spec:
             name: {{ include "falcosidekick.fullname" . }}-ui-redis
             defaultMode: 0444
             items:
-              - key: redis-stack.config
-                path: redis-stack.config
+              - key: redis-stack.conf
+                path: redis-stack.conf
       {{ end }}
   {{- if .Values.webui.redis.storageEnabled }}
   volumeClaimTemplates:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind chart-release

**Any specific area of the project related to this PR?**

/area falcosidekick-chart

**What this PR does / why we need it**:

redis-stack expects [configuration in file /redis-stack.conf](https://github.com/redis-stack/redis-stack/blob/9948f22324e7a89569a83c20d023cb91d0a92c3a/etc/scripts/entrypoint.sh#L9):

```bash
if [ -f /redis-stack.conf ]; then
    CONFFILE=/redis-stack.conf
fi
```

However currently the ConfigMap/StatefulSet templates mount the configuration over at `/redis-stack.config`, so it doesn't get applied despite defining `customConfig` in values [[1](https://github.com/falcosecurity/charts/blob/9483726553d9d2a3b46c0fc27764b5c1161433ae/charts/falcosidekick/templates/configmap-ui.yaml#L13)] [[2](https://github.com/falcosecurity/charts/blob/9483726553d9d2a3b46c0fc27764b5c1161433ae/charts/falcosidekick/templates/deployment-ui.yaml#L249)] [[3](https://github.com/falcosecurity/charts/blob/9483726553d9d2a3b46c0fc27764b5c1161433ae/charts/falcosidekick/templates/deployment-ui.yaml#L274)]:

```yaml
{{- if .Values.webui.redis.customConfig }}
- name: config
  mountPath: /redis-stack.config
  subPath: redis-stack.config
{{- end }}
```

Testing with `values.yaml`:

```yaml
falcosidekick:
  webui:
    redis:
      customConfig: 
        - maxmemory-policy allkeys-lfu
        - maxmemory 3000mb
```

And running `redis-cli config get maxmemory` returns no configuration, whereas it should return:

```bash
1) "maxmemory"
2) "3145728000"
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**

    * [x]  Chart Version bumped

    * [ ]  Variables are documented in the README.md

    * [x]  CHANGELOG.md updated

