### PR TITLE
falco: when leastPrivileged is true, set the apparmor profile to …

### DIFF
--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v4.12.0
+
+* Set apparmor to `unconfined` (disabled) when `leastPrivileged: true` and (`kind: modern_ebpf` or `kind: ebpf`)
+
 ## v4.11.2
 
 * only prints env key if there are env values to be passed on `falcoctl.initContainer` and `falcoctl.sidecar`

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 4.11.2
+version: 4.12.0
 appVersion: "0.39.1"
 description: Falco
 keywords:

--- a/charts/falco/README.md
+++ b/charts/falco/README.md
@@ -581,7 +581,7 @@ If you use a Proxy in your cluster, the requests between `Falco` and `Falcosidek
 
 ## Configuration
 
-The following table lists the main configurable parameters of the falco chart v4.11.2 and their default values. See [values.yaml](./values.yaml) for full list.
+The following table lists the main configurable parameters of the falco chart v4.12.0 and their default values. See [values.yaml](./values.yaml) for full list.
 
 ## Values
 

--- a/charts/falco/templates/pod-template.tpl
+++ b/charts/falco/templates/pod-template.tpl
@@ -12,6 +12,17 @@ metadata:
     {{- if and .Values.certs (not .Values.certs.existingSecret) }}
     checksum/certs: {{ include (print $.Template.BasePath "/certs-secret.yaml") . | sha256sum }}
     {{- end }}
+    {{- if .Values.driver.enabled }}
+    {{- if (or (eq .Values.driver.kind "modern_ebpf") (eq .Values.driver.kind "modern-bpf")) }}
+    {{- if .Values.driver.modernEbpf.leastPrivileged }}
+    container.apparmor.security.beta.kubernetes.io/{{ .Chart.Name }}: unconfined
+    {{- end }}
+    {{- else if eq .Values.driver.kind "ebpf" }}
+    {{- if .Values.driver.ebpf.leastPrivileged }}
+    container.apparmor.security.beta.kubernetes.io/{{ .Chart.Name }}: unconfined
+    {{- end }}
+    {{- end }}
+    {{- end }}
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->
<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
It appears that when setting `leastPrivileged: true`, apparmor does not not allow falco to ptrace, which appears to leave the container fields null. 


```
Oct 24 09:52:57 hostname kernel: audit: type=1400 audit(1729785177.339:404624): apparmor="DENIED" operation="ptrace" profile="cri-containerd.apparmor.d" pid=2389102 comm="falco" requested_mask="read" denied_mask="read" peer="unconfined"
```

If `leastPrivileged: true`, set the apparmor profile to `unconfined`.

@leogr 
This just a request for comments, as I'm not sure if this if the best way to solve the issue.
Or perhaps there should be an optional field in the helm file that allows specifying a apparmor profile (custom or unconfined.)



**Which issue(s) this PR fixes**:
falcosecurity/falco#3345

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] CHANGELOG.md updated
