### PR TITLE
new(falco/collectors): expose new config options for k8smeta

### DIFF
--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v4.13.0
+
+* Expose new config entries for k8smeta plugin:`verbosity` and `hostProc`.
+
 ## v4.12.0
 
 * Set apparmor to `unconfined` (disabled) when `leastPrivileged: true` and (`kind: modern_ebpf` or `kind: ebpf`)

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 4.12.0
+version: 4.13.0
 appVersion: "0.39.1"
 description: Falco
 keywords:

--- a/charts/falco/README.md
+++ b/charts/falco/README.md
@@ -581,7 +581,7 @@ If you use a Proxy in your cluster, the requests between `Falco` and `Falcosidek
 
 ## Configuration
 
-The following table lists the main configurable parameters of the falco chart v4.12.0 and their default values. See [values.yaml](./values.yaml) for full list.
+The following table lists the main configurable parameters of the falco chart v4.13.0 and their default values. See [values.yaml](./values.yaml) for full list.
 
 ## Values
 
@@ -602,7 +602,7 @@ The following table lists the main configurable parameters of the falco chart v4
 | collectors.docker.enabled | bool | `true` | Enable Docker support. |
 | collectors.docker.socket | string | `"/var/run/docker.sock"` | The path of the Docker daemon socket. |
 | collectors.enabled | bool | `true` | Enable/disable all the metadata collectors. |
-| collectors.kubernetes | object | `{"collectorHostname":"","collectorPort":"","enabled":false,"pluginRef":"ghcr.io/falcosecurity/plugins/plugin/k8smeta:0.2.0"}` | kubernetes holds the configuration for the kubernetes collector. Starting from version 0.37.0 of Falco, the legacy kubernetes client has been removed. A new standalone component named k8s-metacollector and a Falco plugin have been developed to solve the issues that were present in the old implementation. More info here: https://github.com/falcosecurity/falco/issues/2973 |
+| collectors.kubernetes | object | `{"collectorHostname":"","collectorPort":"","enabled":false,"hostProc":"/host","pluginRef":"ghcr.io/falcosecurity/plugins/plugin/k8smeta:0.2.0","verbosity":"info"}` | kubernetes holds the configuration for the kubernetes collector. Starting from version 0.37.0 of Falco, the legacy kubernetes client has been removed. A new standalone component named k8s-metacollector and a Falco plugin have been developed to solve the issues that were present in the old implementation. More info here: https://github.com/falcosecurity/falco/issues/2973 |
 | collectors.kubernetes.collectorHostname | string | `""` | collectorHostname is the address of the k8s-metacollector. When not specified it will be set to match k8s-metacollector service. e.x: falco-k8smetacollecto.falco.svc. If for any reason you need to override it, make sure to set here the address of the k8s-metacollector. It is used by the k8smeta plugin to connect to the k8s-metacollector. |
 | collectors.kubernetes.collectorPort | string | `""` | collectorPort designates the port on which the k8s-metacollector gRPC service listens. If not specified the value of the port named `broker-grpc` in k8s-metacollector.service.ports is used. The default values is 45000. It is used by the k8smeta plugin to connect to the k8s-metacollector. |
 | collectors.kubernetes.enabled | bool | `false` | enabled specifies whether the Kubernetes metadata should be collected using the k8smeta plugin and the k8s-metacollector component. It will deploy the k8s-metacollector external component that fetches Kubernetes metadata and pushes them to Falco instances. For more info see: https://github.com/falcosecurity/k8s-metacollector https://github.com/falcosecurity/charts/tree/master/charts/k8s-metacollector When this option is disabled, Falco falls back to the container annotations to grab the metadata. In such a case, only the ID, name, namespace, labels of the pod will be available. |

--- a/charts/falco/templates/_helpers.tpl
+++ b/charts/falco/templates/_helpers.tpl
@@ -361,7 +361,7 @@ be temporary and will stay here until we move this logic to the falcoctl tool.
 {{- if not $hasConfig -}}
 {{- $listenPort := default (index .Values "k8s-metacollector" "service" "ports" "broker-grpc" "port") .Values.collectors.kubernetes.collectorPort -}}
 {{- $listenPort = int $listenPort -}}
-{{- $pluginConfig := dict "name" "k8smeta" "library_path" "libk8smeta.so" "init_config" (dict "collectorHostname" $hostname "collectorPort" $listenPort "nodeName" "${FALCO_K8S_NODE_NAME}") -}}
+{{- $pluginConfig := dict "name" "k8smeta" "library_path" "libk8smeta.so" "init_config" (dict "collectorHostname" $hostname "collectorPort" $listenPort "nodeName" "${FALCO_K8S_NODE_NAME}" "verbosity" .Values.collectors.kubernetes.verbosity "hostProc" .Values.collectors.kubernetes.hostProc) -}}
 {{- $newConfig := append .Values.falco.plugins $pluginConfig -}}
 {{- $_ := set .Values.falco "plugins" ($newConfig | uniq) -}}
 {{- $loadedPlugins := append .Values.falco.load_plugins "k8smeta" -}}

--- a/charts/falco/tests/unit/k8smetacollectorDependency_test.go
+++ b/charts/falco/tests/unit/k8smetacollectorDependency_test.go
@@ -23,10 +23,11 @@ import (
 	"strings"
 	"testing"
 
+	"slices"
+
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"slices"
 )
 
 const chartPath = "../../"
@@ -114,6 +115,7 @@ func TestPluginConfigurationInFalcoConfig(t *testing.T) {
 				// Get init config.
 				initConfig, ok := plugin["init_config"]
 				require.True(t, ok)
+				require.Len(t, initConfig, 5, "checking number of config entries in the init section")
 				initConfigMap := initConfig.(map[string]interface{})
 				// Check that the collector port is correctly set.
 				port := initConfigMap["collectorPort"]
@@ -124,7 +126,12 @@ func TestPluginConfigurationInFalcoConfig(t *testing.T) {
 				// Check that the collector hostname is correctly set.
 				hostName := initConfigMap["collectorHostname"]
 				require.Equal(t, fmt.Sprintf("%s-k8s-metacollector.default.svc", releaseName), hostName.(string))
-
+				// Check that the loglevel has been set.
+				verbosity := initConfigMap["verbosity"]
+				require.Equal(t, "info", verbosity.(string))
+				// Check that host proc fs has been set.
+				hostProc := initConfigMap["hostProc"]
+				require.Equal(t, "/host", hostProc.(string))
 				// Check that the library path is set.
 				libPath := plugin["library_path"]
 				require.Equal(t, "libk8smeta.so", libPath)
@@ -140,6 +147,7 @@ func TestPluginConfigurationInFalcoConfig(t *testing.T) {
 				// Get init config.
 				initConfig, ok := plugin["init_config"]
 				require.True(t, ok)
+				require.Len(t, initConfig, 5, "checking number of config entries in the init section")
 				initConfigMap := initConfig.(map[string]interface{})
 				// Check that the collector port is correctly set.
 				port := initConfigMap["collectorPort"]
@@ -150,6 +158,12 @@ func TestPluginConfigurationInFalcoConfig(t *testing.T) {
 				// Check that the collector hostname is correctly set.
 				hostName := initConfigMap["collectorHostname"]
 				require.Equal(t, fmt.Sprintf("%s-k8s-metacollector.test.svc", releaseName), hostName.(string))
+				// Check that the loglevel has been set.
+				verbosity := initConfigMap["verbosity"]
+				require.Equal(t, "info", verbosity.(string))
+				// Check that host proc fs has been set.
+				hostProc := initConfigMap["hostProc"]
+				require.Equal(t, "/host", hostProc.(string))
 
 				// Check that the library path is set.
 				libPath := plugin["library_path"]
@@ -166,6 +180,7 @@ func TestPluginConfigurationInFalcoConfig(t *testing.T) {
 				// Get init config.
 				initConfig, ok := plugin["init_config"]
 				require.True(t, ok)
+				require.Len(t, initConfig, 5, "checking number of config entries in the init section")
 				initConfigMap := initConfig.(map[string]interface{})
 				// Check that the collector port is correctly set.
 				port := initConfigMap["collectorPort"]
@@ -176,6 +191,12 @@ func TestPluginConfigurationInFalcoConfig(t *testing.T) {
 				// Check that the collector hostname is correctly set.
 				hostName := initConfigMap["collectorHostname"]
 				require.Equal(t, "collector.default.svc", hostName.(string))
+				// Check that the loglevel has been set.
+				verbosity := initConfigMap["verbosity"]
+				require.Equal(t, "info", verbosity.(string))
+				// Check that host proc fs has been set.
+				hostProc := initConfigMap["hostProc"]
+				require.Equal(t, "/host", hostProc.(string))
 
 				// Check that the library path is set.
 				libPath := plugin["library_path"]
@@ -194,6 +215,7 @@ func TestPluginConfigurationInFalcoConfig(t *testing.T) {
 				// Get init config.
 				initConfig, ok := plugin["init_config"]
 				require.True(t, ok)
+				require.Len(t, initConfig, 5, "checking number of config entries in the init section")
 				initConfigMap := initConfig.(map[string]interface{})
 				// Check that the collector port is correctly set.
 				port := initConfigMap["collectorPort"]
@@ -204,6 +226,12 @@ func TestPluginConfigurationInFalcoConfig(t *testing.T) {
 				// Check that the collector hostname is correctly set.
 				hostName := initConfigMap["collectorHostname"]
 				require.Equal(t, "collector.test.svc", hostName.(string))
+				// Check that the loglevel has been set.
+				verbosity := initConfigMap["verbosity"]
+				require.Equal(t, "info", verbosity.(string))
+				// Check that host proc fs has been set.
+				hostProc := initConfigMap["hostProc"]
+				require.Equal(t, "/host", hostProc.(string))
 
 				// Check that the library path is set.
 				libPath := plugin["library_path"]
@@ -220,6 +248,7 @@ func TestPluginConfigurationInFalcoConfig(t *testing.T) {
 				// Get init config.
 				initConfig, ok := plugin["init_config"]
 				require.True(t, ok)
+				require.Len(t, initConfig, 5, "checking number of config entries in the init section")
 				initConfigMap := initConfig.(map[string]interface{})
 				// Check that the collector port is correctly set.
 				port := initConfigMap["collectorPort"]
@@ -230,6 +259,12 @@ func TestPluginConfigurationInFalcoConfig(t *testing.T) {
 				// Check that the collector hostname is correctly set.
 				hostName := initConfigMap["collectorHostname"]
 				require.Equal(t, "test", hostName.(string))
+				// Check that the loglevel has been set.
+				verbosity := initConfigMap["verbosity"]
+				require.Equal(t, "info", verbosity.(string))
+				// Check that host proc fs has been set.
+				hostProc := initConfigMap["hostProc"]
+				require.Equal(t, "/host", hostProc.(string))
 
 				// Check that the library path is set.
 				libPath := plugin["library_path"]
@@ -249,6 +284,7 @@ func TestPluginConfigurationInFalcoConfig(t *testing.T) {
 				// Get init config.
 				initConfig, ok := plugin["init_config"]
 				require.True(t, ok)
+				require.Len(t, initConfig, 5, "checking number of config entries in the init section")
 				initConfigMap := initConfig.(map[string]interface{})
 				// Check that the collector port is correctly set.
 				port := initConfigMap["collectorPort"]
@@ -259,6 +295,12 @@ func TestPluginConfigurationInFalcoConfig(t *testing.T) {
 				// Check that the collector hostname is correctly set.
 				hostName := initConfigMap["collectorHostname"]
 				require.Equal(t, "test-with-override", hostName.(string))
+				// Check that the loglevel has been set.
+				verbosity := initConfigMap["verbosity"]
+				require.Equal(t, "info", verbosity.(string))
+				// Check that host proc fs has been set.
+				hostProc := initConfigMap["hostProc"]
+				require.Equal(t, "/host", hostProc.(string))
 
 				// Check that the library path is set.
 				libPath := plugin["library_path"]
@@ -286,6 +328,12 @@ func TestPluginConfigurationInFalcoConfig(t *testing.T) {
 				// Check that the collector hostname is correctly set.
 				hostName := initConfigMap["collectorHostname"]
 				require.Equal(t, fmt.Sprintf("%s-k8s-metacollector.default.svc", releaseName), hostName.(string))
+				// Check that the loglevel has been set.
+				verbosity := initConfigMap["verbosity"]
+				require.Equal(t, "info", verbosity.(string))
+				// Check that host proc fs has been set.
+				hostProc := initConfigMap["hostProc"]
+				require.Equal(t, "/host", hostProc.(string))
 
 				// Check that the library path is set.
 				libPath := plugin["library_path"]
@@ -293,7 +341,40 @@ func TestPluginConfigurationInFalcoConfig(t *testing.T) {
 			},
 		},
 		{
-			"drive disabled",
+			"set collector logger level and hostProc",
+			map[string]string{
+				"collectors.kubernetes.verbosity": "trace",
+				"collectors.kubernetes.hostProc":  "/host/test",
+			},
+			func(t *testing.T, config any) {
+				plugin := config.(map[string]interface{})
+				// Get init config.
+				initConfig, ok := plugin["init_config"]
+				require.True(t, ok)
+				require.Len(t, initConfig, 5, "checking number of config entries in the init section")
+				initConfigMap := initConfig.(map[string]interface{})
+				// Check that the collector port is correctly set.
+				port := initConfigMap["collectorPort"]
+				require.Equal(t, float64(45000), port.(float64))
+				// Check that the collector nodeName is correctly set.
+				nodeName := initConfigMap["nodeName"]
+				require.Equal(t, "${FALCO_K8S_NODE_NAME}", nodeName.(string))
+				// Check that the collector hostname is correctly set.
+				hostName := initConfigMap["collectorHostname"]
+				require.Equal(t, fmt.Sprintf("%s-k8s-metacollector.default.svc", releaseName), hostName.(string))
+				// Check that the loglevel has been set.
+				verbosity := initConfigMap["verbosity"]
+				require.Equal(t, "trace", verbosity.(string))
+				// Check that host proc fs has been set.
+				hostProc := initConfigMap["hostProc"]
+				require.Equal(t, "/host/test", hostProc.(string))
+				// Check that the library path is set.
+				libPath := plugin["library_path"]
+				require.Equal(t, "libk8smeta.so", libPath)
+			},
+		},
+		{
+			"driver disabled",
 			map[string]string{
 				"driver.enabled": "false",
 			},

--- a/charts/falco/values.yaml
+++ b/charts/falco/values.yaml
@@ -402,6 +402,13 @@ collectors:
     # the value of the port named `broker-grpc` in k8s-metacollector.service.ports is used. The default values is 45000.
     # It is used by the k8smeta plugin to connect to the k8s-metacollector.
     collectorPort: ""
+    # verbosity level for the plugin logger: trace, debug, info, warning, error, critical.
+    verbosity: info
+    # The plugin needs to scan the '/proc' of the host on which is running.
+    # In Falco usually we put the host '/proc' folder under '/host/proc' so
+    # the default for this config is '/host'.
+    # The path used here must not have a final '/'.
+    hostProc: /host
 
 
 ###########################


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

 /kind documentation

> /kind failing-test

 /kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

 /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

 /area falco-chart

> /area falco-exporter-chart

> /area falcosidekick-chart

> /area falco-talon

> /area event-generator-chart

> /area k8s-metacollector

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

new(falco/collectors): expose new config options for k8smeta pluginsKcl/add k8smeta config options

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
