### PR TITLE
fix(falcosidekick): Allow overriding the Prometheus scrape Service annotation

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.9.5
+
+- Move the `prometheus.io/scrape` annotation to the default values, to allow overrides.
+
 ## 0.9.4
 
 - Fix Prometheus metrics names in Prometheus Rule

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.30.0
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.9.4
+version: 0.9.5
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/README.md
+++ b/charts/falcosidekick/README.md
@@ -649,7 +649,7 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | replicaCount | int | `2` | number of running pods |
 | resources | object | `{}` | The resources for falcosdekick pods |
 | securityContext | object | `{}` | Sidekick container securityContext |
-| service.annotations | object | `{}` | Service annotations |
+| service.annotations | object | `{"prometheus.io/scrape":"true"}` | Service annotations |
 | service.port | int | `2801` | Service port |
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceMonitor.additionalLabels | object | `{}` | specify Additional labels to be added on the Service Monitor. |

--- a/charts/falcosidekick/templates/service.yaml
+++ b/charts/falcosidekick/templates/service.yaml
@@ -17,7 +17,6 @@ metadata:
     {{- with .Values.service.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    prometheus.io/scrape: "true"
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/falcosidekick/values.yaml
+++ b/charts/falcosidekick/values.yaml
@@ -1118,7 +1118,8 @@ service:
   # -- Service port
   port: 2801
   # -- Service annotations
-  annotations: {}
+  annotations:
+    prometheus.io/scrape: "true"
     # networking.gke.io/load-balancer-type: Internal
 
 ingress:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind chart-release

**Any specific area of the project related to this PR?**

/area falcosidekick-chart

**What this PR does / why we need it**:

We are working on a migration from a deprecated Prometheus setup to one based on the Prometheus Kubernetes Operator.
Since metrics scraped by the operator-managed instances are targeting ServiceMonitor and PodMonitor resources, we need to be able to configure the `prometheus.io/scrape` Service annotation to gradually disable scraping from our deprecated instances.

**Which issue(s) this PR fixes**:

Because the `prometheus.io/scrape` annotation is hard-coded in the Service template **and** it's the last entry in the `annotations` map, there's no way to include custom values after it.

This PR simply moves the hard-coded annotation to before the user-provided values, so at least they have an escape hatch in case they need to override the value.

**Special notes for your reviewer**:

You can test with:
```sh
helm template falcosidekick charts/falcosidekick -s templates/service.yaml -f - <<EOF | yq '.metadata.annotations["prometheus.io/scrape"]'
service:
  annotations:
    prometheus.io/scrape: "false"
EOF
```

The final template will include duplicate values, but the override will take precedence when the yaml gets parsed/applied to the cluster.
```yaml
apiVersion: v1
kind: Service
metadata:
  name: falcosidekick
  annotations:
    prometheus.io/scrape: "true"
    prometheus.io/scrape: "false"
  ...
```

The duplicated keys will be removed by the cluster.

I considered going with a different approach based on something like `.Values.service.prometheusScrape`, but decided against it due to it requiring changes to the `values.yaml` structure.

**Checklist**

- [x] Chart Version bumped
- [x] CHANGELOG.md updated
