### PR TITLE
fix: Use rules_files instead of deprecated rules_file in README.md config snippet

### DIFF
--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -3,11 +3,17 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v4.14.2
+
+* fix(falco/readme): use `rules_files` instead of deprecated `rules_file` in README config snippet
+
 ## v4.14.1
+
 * fix(falco/dashboard): make pod variable independent of triggered rules. CPU and memory are now visible for each 
   pod, even when no rules have been triggered for that falco instance.
 
 ## v4.14.0
+
 * Bump k8smeta plugin to 0.2.1, see: https://github.com/falcosecurity/plugins/releases/tag/plugins%2Fk8smeta%2Fv0.2.1
 
 ## v4.13.0
@@ -31,6 +37,7 @@ numbering uses [semantic versioning](http://semver.org).
 * new(falco): add grafana dashboard for falco
 
 ## v4.10.0
+
 * Bump Falco to v0.39.1
 
 ## v4.9.1
@@ -38,6 +45,7 @@ numbering uses [semantic versioning](http://semver.org).
 * feat(falco): add labels and annotations to the metrics service
 
 ## v4.9.0
+
 * Bump Falco to v0.39.0
 * update(falco): add new configuration entries for Falco
   This commit adds new config keys introduces in Falco 0.39.0.

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 4.14.1
+version: 4.14.2
 appVersion: "0.39.1"
 description: Falco
 keywords:

--- a/charts/falco/README.md
+++ b/charts/falco/README.md
@@ -383,7 +383,7 @@ services:
         protocol: TCP
 
 falco:
-  rules_file:
+  rules_files:
     - /etc/falco/k8s_audit_rules.yaml
     - /etc/falco/rules.d
   plugins:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind documentation

**Any specific area of the project related to this PR?**
/area falco-chart

**What this PR does / why we need it**:
Current snippet in chars/falco/README.md that uses `rules_file` causes collision with `rules_files` and falco does not start

```
Tue Nov 12 14:23:17 2024: Using deprecated config key 'rules_file' (singular form). Please use new 'rules_files' config key (plural form).
Error: Error reading config file (/etc/falco/falco.yaml): both 'rules_files' and 'rules_file' keys set
```