### PR TITLE
fix(falco): set dnsPolicy to ClusterFirstWithHostNet when gvisor driver is enabled

### DIFF
--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v4.16.2
+
+* fix(falco): set dnsPolicy to ClusterFirstWithHostNet when gvisor driver is enabled to prevent DNS lookup failures for cluster-internal services
+
 ## v4.16.1
 
 * fix(falco/serviceMonitor): set service label selector

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 4.16.1
+version: 4.16.2
 appVersion: "0.39.2"
 description: Falco
 keywords:

--- a/charts/falco/README.md
+++ b/charts/falco/README.md
@@ -581,7 +581,7 @@ If you use a Proxy in your cluster, the requests between `Falco` and `Falcosidek
 
 ## Configuration
 
-The following table lists the main configurable parameters of the falco chart v4.16.1 and their default values. See [values.yaml](./values.yaml) for full list.
+The following table lists the main configurable parameters of the falco chart v4.16.2 and their default values. See [values.yaml](./values.yaml) for full list.
 
 ## Values
 

--- a/charts/falco/templates/pod-template.tpl
+++ b/charts/falco/templates/pod-template.tpl
@@ -60,6 +60,7 @@ spec:
   {{- if eq .Values.driver.kind "gvisor" }}
   hostNetwork: true
   hostPID: true
+  dnsPolicy: ClusterFirstWithHostNet
   {{- end }}
   containers:
     - name: {{ .Chart.Name }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area falco-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR modify the helm chart for Falco to set the `dnsPolicy` of the falco pod to `ClusterFirstWithHostNet` when the gVisor driver is enabled.

This is needed because right now, the dnsPolicy falls back to the `Default` mode of Kubernetes (see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) as the falco pod runs with `hostNetwork` set to true when gVisor is enabled https://github.com/falcosecurity/charts/blob/15f97d55f6c2ddbeb6fefbbb4e8f663d835005af/charts/falco/templates/pod-template.tpl#L60-L63

This is an issue as this `Default` mode uses the node DNS servers, and not the Kubernetes cluster DNS server, causing all lookups to *.cluster.local to fail. 

For example, this breaks the falco sidekick integration as it tries to resolve `falco-falcosidekick` (or `falco-falcosidekick.svc.cluster.local` if `falcosidekick.fullfqdn` is set to true)

https://github.com/falcosecurity/charts/blob/15f97d55f6c2ddbeb6fefbbb4e8f663d835005af/charts/falco/templates/_helpers.tpl#L140-L144

Setting `dnsPolicy` to `ClusterFirstWithHostNet` shouldn't cause breaking changes as this mode fall backs to the node's DNS servers if the request is not for a `.cluster.local` domain. 

**Which issue(s) this PR fixes**:

Fixes #793 

**Special notes for your reviewer**:

None

**Checklist**

None applicable
