### PR TITLE
feat/fix(falco): adding imagePullSecrets at the service account level

### DIFF
--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v4.17.1
+
+* feat/fix(falco): fixing imagePullSecrets(should be an object) + adding it at the SA level
+
 ## v4.17.0
 
 * update(falco): bump k8saudit version to 0.11

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 4.17.0
+version: 4.17.1
 appVersion: "0.39.2"
 description: Falco
 keywords:

--- a/charts/falco/README.md
+++ b/charts/falco/README.md
@@ -782,6 +782,7 @@ The following table lists the main configurable parameters of the falco chart v4
 | resources.limits | object | `{"cpu":"1000m","memory":"1024Mi"}` | Maximum amount of resources that Falco container could get. If you are enabling more than one source in falco, than consider to increase the cpu limits. |
 | resources.requests | object | `{"cpu":"100m","memory":"512Mi"}` | Although resources needed are subjective on the actual workload we provide a sane defaults ones. If you have more questions or concerns, please refer to #falco slack channel for more info about it. |
 | scc.create | bool | `true` | Create OpenShift's Security Context Constraint. |
+| serviceAccount.imagePullSecrets | object | `{}` | Secrets containing credentials when pulling from private/secure registries using the service account. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |

--- a/charts/falco/templates/serviceaccount.yaml
+++ b/charts/falco/templates/serviceaccount.yaml
@@ -1,6 +1,10 @@
 
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 kind: ServiceAccount
 metadata:
   name: {{ include "falco.serviceAccountName" . }}

--- a/charts/falco/values.yaml
+++ b/charts/falco/values.yaml
@@ -15,7 +15,7 @@ image:
   tag: ""
 
 # -- Secrets containing credentials when pulling from private/secure registries.
-imagePullSecrets: []
+imagePullSecrets: {}
 # -- Put here the new name if you want to override the release name used for Falco components.
 nameOverride: ""
 # -- Same as nameOverride but for the fullname.
@@ -27,6 +27,8 @@ namespaceOverride: ""
 podAnnotations: {}
 
 serviceAccount:
+  # -- Secrets containing credentials when pulling from private/secure registries.
+  imagePullSecrets: {}
   # -- Specifies whether a service account should be created.
   create: true
   # -- Annotations to add to the service account.

--- a/charts/falco/values.yaml
+++ b/charts/falco/values.yaml
@@ -15,7 +15,7 @@ image:
   tag: ""
 
 # -- Secrets containing credentials when pulling from private/secure registries.
-imagePullSecrets: {}
+imagePullSecrets: []
 # -- Put here the new name if you want to override the release name used for Falco components.
 nameOverride: ""
 # -- Same as nameOverride but for the fullname.
@@ -28,7 +28,7 @@ podAnnotations: {}
 
 serviceAccount:
   # -- Secrets containing credentials when pulling from private/secure registries.
-  imagePullSecrets: {}
+  imagePullSecrets: []
   # -- Specifies whether a service account should be created.
   create: true
   # -- Annotations to add to the service account.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area falco-chart

> /area falco-exporter-chart

> /area falcosidekick-chart

> /area falco-talon-chart

> /area event-generator-chart

> /area k8s-metacollector-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This pull request includes updates to the Falco Helm Chart to fix and enhance the handling of `imagePullSecrets`. The changes include modifications to the `values.yaml`, `serviceaccount.yaml`, `README.md`, `Chart.yaml`, and `CHANGELOG.md` files.

Key changes:

Enhancements and fixes:

* [`charts/falco/values.yaml`](diffhunk://#diff-ef3f1a0c0800c919d45ffa98656d27cee2803963e4e13622ac22a08ce6548f0cR30-R31): Added `imagePullSecrets` to the service account configuration to support pulling from private/secure registries.
* [`charts/falco/templates/serviceaccount.yaml`](diffhunk://#diff-ddf35a2d6a75d3643af6fd4b8f4f43b315492464325e24ab03a1b1c16ed4dd66R4-R7): Updated the service account template to include `imagePullSecrets`.

Documentation updates:

* [`charts/falco/README.md`](diffhunk://#diff-fc264f74c2cd8e3b933ee3aeedb36b7a83a140405e3eed2d911a510d7ec926eeR785): Added documentation for the `imagePullSecrets` parameter in the service account section.
* [`charts/falco/CHANGELOG.md`](diffhunk://#diff-d1613bbf16ff37c41e8a790f210754a66892d89942386eadbd7480e3d17f6b08R6-R9): Documented the changes in version 4.17.1, including the fix for `imagePullSecrets`.

Version bump:

* [`charts/falco/Chart.yaml`](diffhunk://#diff-d88def4df1cadd77b7995684cd6fa167bc84c9998f8bf0a5e147893ba53ee3deL3-R3): Updated the chart version from 4.17.0 to 4.17.1.

For most use cases, it is recommended to specify imagePullSecrets at the ServiceAccount level if all pods using that ServiceAccount need access to the same image pull secrets. This approach simplifies management and ensures consistency across your deployments.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Potentiall Fixes # https://github.com/falcosecurity/charts/issues/673

**Special notes for your reviewer**:

I've already fixed the corrisponding labels in GitHub

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] CHANGELOG.md updated
