### PR TITLE
Add ports definition for webserver

### DIFF
--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
+## v4.17.2
+
+* update(falco): add ports definition in falco container spec
 
 ## v4.17.1
 

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 4.17.1
+version: 4.17.2
 appVersion: "0.39.2"
 description: Falco
 keywords:

--- a/charts/falco/README.md
+++ b/charts/falco/README.md
@@ -585,7 +585,7 @@ If you use a Proxy in your cluster, the requests between `Falco` and `Falcosidek
 
 ## Configuration
 
-The following table lists the main configurable parameters of the falco chart v4.17.1 and their default values. See [values.yaml](./values.yaml) for full list.
+The following table lists the main configurable parameters of the falco chart v4.17.2 and their default values. See [values.yaml](./values.yaml) for full list.
 
 ## Values
 

--- a/charts/falco/templates/pod-template.tpl
+++ b/charts/falco/templates/pod-template.tpl
@@ -109,6 +109,10 @@ spec:
       {{- end }}
       tty: {{ .Values.tty }}
       {{- if .Values.falco.webserver.enabled }}
+      ports:
+        - containerPort: {{ .Values.falco.webserver.listen_port }}
+          name: web
+          protocol: TCP
       livenessProbe:
         initialDelaySeconds: {{ .Values.healthChecks.livenessProbe.initialDelaySeconds }}
         timeoutSeconds: {{ .Values.healthChecks.livenessProbe.timeoutSeconds }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/area falco-chart

**What this PR does / why we need it**:

This PR adds a ports: section to the Falco container when the webserver/metrics settings are enabled. Without this change, the port isn’t properly exposed, preventing tools like Prometheus or Grafana from scraping metrics. By exposing the webserver port in the Pod spec, other services can now access it as intended.

**Which issue(s) this PR fixes**:

Fixes #812

**Special notes for your reviewer**:

No special notes. I’ve already updated the corresponding labels on GitHub.

**Checklist**
- [x] Chart Version bumped
- [x] ~~Variables are documented in the README.md~~
- [x] CHANGELOG.md updated
