### PR TITLE
new(falco): adding imagePullSecrets at the service account level

### DIFF
--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
-## v4.21.1
+## v4.21.0
 
 * feat(falco): adding imagePullSecrets at the service account level
 

--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v4.21.1
+
+* feat(falco): adding imagePullSecrets at the service account level
+
 ## v4.20.1
 
 * correctly mount the volumes based on socket path

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 4.21.1
+version: 4.21.0
 appVersion: "0.40.0"
 description: Falco
 keywords:

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 4.20.1
+version: 4.21.1
 appVersion: "0.40.0"
 description: Falco
 keywords:

--- a/charts/falco/README.md
+++ b/charts/falco/README.md
@@ -796,6 +796,7 @@ The following table lists the main configurable parameters of the falco chart v4
 | resources.limits | object | `{"cpu":"1000m","memory":"1024Mi"}` | Maximum amount of resources that Falco container could get. If you are enabling more than one source in falco, than consider to increase the cpu limits. |
 | resources.requests | object | `{"cpu":"100m","memory":"512Mi"}` | Although resources needed are subjective on the actual workload we provide a sane defaults ones. If you have more questions or concerns, please refer to #falco slack channel for more info about it. |
 | scc.create | bool | `true` | Create OpenShift's Security Context Constraint. |
+| serviceAccount.imagePullSecrets | list | `[]` | Secrets containing credentials when pulling from private/secure registries using the service account. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |

--- a/charts/falco/README.md
+++ b/charts/falco/README.md
@@ -585,7 +585,7 @@ If you use a Proxy in your cluster, the requests between `Falco` and `Falcosidek
 
 ## Configuration
 
-The following table lists the main configurable parameters of the falco chart v4.20.1 and their default values. See [values.yaml](./values.yaml) for full list.
+The following table lists the main configurable parameters of the falco chart v4.21.0 and their default values. See [values.yaml](./values.yaml) for full list.
 
 ## Values
 
@@ -796,9 +796,9 @@ The following table lists the main configurable parameters of the falco chart v4
 | resources.limits | object | `{"cpu":"1000m","memory":"1024Mi"}` | Maximum amount of resources that Falco container could get. If you are enabling more than one source in falco, than consider to increase the cpu limits. |
 | resources.requests | object | `{"cpu":"100m","memory":"512Mi"}` | Although resources needed are subjective on the actual workload we provide a sane defaults ones. If you have more questions or concerns, please refer to #falco slack channel for more info about it. |
 | scc.create | bool | `true` | Create OpenShift's Security Context Constraint. |
-| serviceAccount.imagePullSecrets | list | `[]` | Secrets containing credentials when pulling from private/secure registries using the service account. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
+| serviceAccount.imagePullSecrets | list | `[]` | Secrets containing credentials when pulling from private/secure registries. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | serviceMonitor | object | `{"create":false,"endpointPort":"metrics","interval":"15s","labels":{},"path":"/metrics","relabelings":[],"scheme":"http","scrapeTimeout":"10s","selector":{},"targetLabels":[],"tlsConfig":{}}` | serviceMonitor holds the configuration for the ServiceMonitor CRD. A ServiceMonitor is a custom resource definition (CRD) used to configure how Prometheus should discover and scrape metrics from the Falco service. |
 | serviceMonitor.create | bool | `false` | create specifies whether a ServiceMonitor CRD should be created for a prometheus operator. https://github.com/coreos/prometheus-operator Enable it only if the ServiceMonitor CRD is installed in your cluster. |

--- a/charts/falco/templates/serviceaccount.yaml
+++ b/charts/falco/templates/serviceaccount.yaml
@@ -1,6 +1,10 @@
 
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 kind: ServiceAccount
 metadata:
   name: {{ include "falco.serviceAccountName" . }}

--- a/charts/falco/values.yaml
+++ b/charts/falco/values.yaml
@@ -27,6 +27,8 @@ namespaceOverride: ""
 podAnnotations: {}
 
 serviceAccount:
+  # -- Secrets containing credentials when pulling from private/secure registries.
+  imagePullSecrets: []
   # -- Specifies whether a service account should be created.
   create: true
   # -- Annotations to add to the service account.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area falco-chart

> /area falco-exporter-chart

> /area falcosidekick-chart

> /area falco-talon-chart

> /area event-generator-chart

> /area k8s-metacollector-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

For most use cases, it is recommended to specify imagePullSecrets at the ServiceAccount level if all pods using that ServiceAccount need access to the same image pull secrets. This approach simplifies management and ensures consistency across your deployments.

This pull request includes updates to the Falco Helm Chart to add support for image pull secrets at the service account level. The most important changes include updating the chart version, adding a new configuration option for image pull secrets, and documenting this new feature.

### Feature Addition:
* [`charts/falco/templates/serviceaccount.yaml`](diffhunk://#diff-ddf35a2d6a75d3643af6fd4b8f4f43b315492464325e24ab03a1b1c16ed4dd66R4-R7): Added the ability to specify `imagePullSecrets` for the service account.
* [`charts/falco/values.yaml`](diffhunk://#diff-ef3f1a0c0800c919d45ffa98656d27cee2803963e4e13622ac22a08ce6548f0cR30-R31): Introduced a new configuration option `serviceAccount.imagePullSecrets` to support credentials for pulling images from private registries.

### Documentation Updates:
* [`charts/falco/README.md`](diffhunk://#diff-fc264f74c2cd8e3b933ee3aeedb36b7a83a140405e3eed2d911a510d7ec926eeR799): Updated the table of configurable parameters to include `serviceAccount.imagePullSecrets`.
* [`charts/falco/CHANGELOG.md`](diffhunk://#diff-d1613bbf16ff37c41e8a790f210754a66892d89942386eadbd7480e3d17f6b08R6-R9): Documented the new feature in the changelog for version 4.19.1.

### Version Bump:
* [`charts/falco/Chart.yaml`](diffhunk://#diff-d88def4df1cadd77b7995684cd6fa167bc84c9998f8bf0a5e147893ba53ee3deL3-R3): Bumped the chart version from 4.19.0 to 4.19.1.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

I've already fixed the corrisponding labels in GitHub

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] CHANGELOG.md updated
