### PR TITLE
feat(helm): add Azure Workload Identity support for Falcosidekick

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.9.9
+
+- Added Azure Workload Identity for Falcosidekick
+
 ## 0.9.8
 
 - Ugrade to Falcosidekick 2.31.1 (fix last release)

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.31.1
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.9.8
+version: 0.9.9
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/README.md
+++ b/charts/falcosidekick/README.md
@@ -220,6 +220,7 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | config.azure.eventHub.namespace | string | `""` | Name of the space the Hub is in |
 | config.azure.podIdentityClientID | string | `""` | Azure Identity Client ID |
 | config.azure.podIdentityName | string | `""` | Azure Identity name |
+| config.azure.workloadIdentityClientID | string | `""` | Azure Workload Identity Client ID |
 | config.azure.resourceGroupName | string | `""` | Azure Resource Group name |
 | config.azure.subscriptionID | string | `""` | Azure Subscription ID |
 | config.bracketreplacer | string | `""` | if not empty, the brackets in keys of Output Fields are replaced |

--- a/charts/falcosidekick/templates/deployment.yaml
+++ b/charts/falcosidekick/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         {{- if and .Values.config.azure.podIdentityClientID .Values.config.azure.podIdentityName }}
         aadpodidbinding: {{ include "falcosidekick.fullname" . }}
         {{- end }}
+        {{- if .Values.config.azure.workloadIdentityClientID }}
+        azure.workload.identity/use: "true"
+        {{- end }}
         {{- if .Values.podLabels }}
         {{ toYaml .Values.podLabels | nindent 8 }}
         {{- end }}

--- a/charts/falcosidekick/templates/rbac.yaml
+++ b/charts/falcosidekick/templates/rbac.yaml
@@ -4,6 +4,19 @@ kind: ServiceAccount
 metadata:
   name: {{ include "falcosidekick.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  {{- if or .Values.config.azure.workloadIdentityClientID (and .Values.config.aws.useirsa .Values.config.aws.rolearn) }}
+  annotations:
+    {{- if .Values.config.azure.workloadIdentityClientID }}
+    azure.workload.identity/client-id: {{ .Values.config.azure.workloadIdentityClientID | quote }}
+    {{- end }}
+    {{- if and .Values.config.aws.useirsa .Values.config.aws.rolearn }}
+    {{- with .Values.customAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    eks.amazonaws.com/role-arn: {{ .Values.config.aws.rolearn | quote }}
+    {{- end }}
+  {{- end }}
+
   {{- if and .Values.config.aws.useirsa .Values.config.aws.rolearn }}
   labels:
     {{- include "falcosidekick.labels" . | nindent 4 }}
@@ -11,11 +24,6 @@ metadata:
     {{- with .Values.customLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  annotations:
-    {{- with .Values.customAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    eks.amazonaws.com/role-arn: {{ .Values.config.aws.rolearn }}
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/falcosidekick/values.yaml
+++ b/charts/falcosidekick/values.yaml
@@ -578,6 +578,8 @@ config:
     podIdentityClientID: ""
     # -- Azure Identity name
     podIdentityName: ""
+    # -- Azure Workload Identity Client ID
+    workloadIdentityClientID: ""
     eventHub:
       # -- Name of the space the Hub is in
       namespace: ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area falco-chart

> /area falco-exporter-chart

/area falcosidekick-chart

> /area falco-talon-chart

> /area event-generator-chart

> /area k8s-metacollector-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Currently, Falcosidekick supports only Azure Pod Identity. However, the modern and Microsoft-recommended approach is to use Workload Identity.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

I've already fixed the corrisponding labels in GitHub

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
