### PR TITLE
fix(falco): ensure .Values.falco.metrics map exists

### DIFF
--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v6.4.1
+
+* Fix rendering issue due to .Values.falco.metrics not being defined
+
 ## v6.4.0
 
 * Added support for dual-stack for the metrics service

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 6.4.0
+version: 6.4.1
 appVersion: "0.41.3"
 description: Falco
 keywords:

--- a/charts/falco/README.md
+++ b/charts/falco/README.md
@@ -583,7 +583,7 @@ If you use a Proxy in your cluster, the requests between `Falco` and `Falcosidek
 
 ## Configuration
 
-The following table lists the main configurable parameters of the falco chart v6.4.0 and their default values. See [values.yaml](./values.yaml) for full list.
+The following table lists the main configurable parameters of the falco chart v6.4.1 and their default values. See [values.yaml](./values.yaml) for full list.
 
 ## Values
 

--- a/charts/falco/templates/_helpers.tpl
+++ b/charts/falco/templates/_helpers.tpl
@@ -428,6 +428,9 @@ Based on the user input it populates the metrics configuration in the falco conf
 {{- if .Values.metrics.enabled -}}
 {{- $_ := set .Values.falco.webserver "prometheus_metrics_enabled" true -}}
 {{- $_ = set .Values.falco.webserver "enabled" true -}}
+{{- if not .Values.falco.metrics -}}
+{{- $_ = set .Values.falco "metrics" dict -}}
+{{- end -}}
 {{- $_ = set .Values.falco.metrics "enabled" .Values.metrics.enabled -}}
 {{- $_ = set .Values.falco.metrics "interval" .Values.metrics.interval -}}
 {{- $_ = set .Values.falco.metrics "output_rule" .Values.metrics.outputRule -}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area falco-chart

> /area falcosidekick-chart

> /area falco-talon-chart

> /area event-generator-chart

> /area k8s-metacollector-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

When using the falco helm chart with the following values:

```
metrics:
  enabled: true
falco:
  webserver:
    prometheus_metrics_enabled: true
```

I get the following error:

```
Error: UPGRADE FAILED: template: falco/templates/daemonset.yaml:21:8: executing "falco/templates/daemonset.yaml" at <include "falco.podTemplate" .>: error calling include: template: falco/templates/pod-template.tpl:10:24: executing "falco.podTemplate" at <include (print $.Template.BasePath "/configmap.yaml") .>: error calling include: template: falco/templates/configmap.yaml:13:8: executing "falco/templates/configmap.yaml" at <include "falco.metricsConfiguration" .>: error calling include: template: falco/templates/_helpers.tpl:450:20: executing "falco.metricsConfiguration" at <.Values.falco.metrics>: wrong type for value; expected map[string]interface {}; got interface {}
```

This PR ensures that the map at `.Values.falco.metrics` exists before setting values to avoid the aforementioned error during the chart templates rendering.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
