### PR TITLE
add startup probe

### DIFF
--- a/charts/falco/CHANGELOG.md
+++ b/charts/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v7.0.3
+
+* Replace initialDelaySeconds in liveness/readiness probes by startupProbe for quicker startup
+
 ## v7.0.2
 
 * Reduce artifact follow default interval value to 1 week

--- a/charts/falco/Chart.yaml
+++ b/charts/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: falco
-version: 7.0.2
+version: 7.0.3
 appVersion: "0.42.1"
 description: Falco
 keywords:

--- a/charts/falco/README.md
+++ b/charts/falco/README.md
@@ -585,7 +585,7 @@ If you use a Proxy in your cluster, the requests between `Falco` and `Falcosidek
 
 ## Configuration
 
-The following table lists the main configurable parameters of the falco chart v7.0.2 and their default values. See [values.yaml](./values.yaml) for full list.
+The following table lists the main configurable parameters of the falco chart v7.0.3 and their default values. See [values.yaml](./values.yaml) for full list.
 
 ## Values
 
@@ -790,13 +790,19 @@ The following table lists the main configurable parameters of the falco chart v7
 | grafana.dashboards.configMaps.falco.name | string | `"falco-grafana-dashboard"` | name specifies the name for the configmap. |
 | grafana.dashboards.configMaps.falco.namespace | string | `""` | namespace specifies the namespace for the configmap. |
 | grafana.dashboards.enabled | bool | `false` | enabled specifies whether the dashboards should be deployed. |
-| healthChecks | object | `{"livenessProbe":{"initialDelaySeconds":60,"periodSeconds":15,"timeoutSeconds":5},"readinessProbe":{"initialDelaySeconds":30,"periodSeconds":15,"timeoutSeconds":5}}` | Parameters used |
-| healthChecks.livenessProbe.initialDelaySeconds | int | `60` | Tells the kubelet that it should wait X seconds before performing the first probe. |
+| healthChecks | object | `{"livenessProbe":{"failureThreshold":3,"initialDelaySeconds":0,"periodSeconds":15,"timeoutSeconds":5},"readinessProbe":{"failureThreshold":3,"initialDelaySeconds":0,"periodSeconds":15,"timeoutSeconds":5},"startupProbe":{"failureThreshold":20,"initialDelaySeconds":3,"periodSeconds":5,"timeoutSeconds":5}}` | Parameters used |
+| healthChecks.livenessProbe.failureThreshold | int | `3` | Number of times in a row before the check fails |
+| healthChecks.livenessProbe.initialDelaySeconds | int | `0` | Tells the kubelet that it should wait X seconds before performing the first probe. |
 | healthChecks.livenessProbe.periodSeconds | int | `15` | Specifies that the kubelet should perform the check every x seconds. |
 | healthChecks.livenessProbe.timeoutSeconds | int | `5` | Number of seconds after which the probe times out. |
-| healthChecks.readinessProbe.initialDelaySeconds | int | `30` | Tells the kubelet that it should wait X seconds before performing the first probe. |
+| healthChecks.readinessProbe.failureThreshold | int | `3` | Number of times in a row before the check fails |
+| healthChecks.readinessProbe.initialDelaySeconds | int | `0` | Tells the kubelet that it should wait X seconds before performing the first probe. |
 | healthChecks.readinessProbe.periodSeconds | int | `15` | Specifies that the kubelet should perform the check every x seconds. |
 | healthChecks.readinessProbe.timeoutSeconds | int | `5` | Number of seconds after which the probe times out. |
+| healthChecks.startupProbe.failureThreshold | int | `20` | failureThreshold * periodSeconds is the max startup time |
+| healthChecks.startupProbe.initialDelaySeconds | int | `3` | Tells the kubelet that it should wait X seconds before performing the first probe. |
+| healthChecks.startupProbe.periodSeconds | int | `5` | Specifies that the kubelet should perform the check every x seconds. |
+| healthChecks.startupProbe.timeoutSeconds | int | `5` | Number of seconds after which the probe times out. |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy. |
 | image.registry | string | `"docker.io"` | The image registry to pull from. |
 | image.repository | string | `"falcosecurity/falco"` | The image repository to pull from |

--- a/charts/falco/templates/pod-template.tpl
+++ b/charts/falco/templates/pod-template.tpl
@@ -99,10 +99,22 @@ spec:
         - containerPort: {{ .Values.falco.webserver.listen_port }}
           name: web
           protocol: TCP
+      startupProbe:
+        initialDelaySeconds: {{ .Values.healthChecks.startupProbe.initialDelaySeconds }}
+        timeoutSeconds: {{ .Values.healthChecks.startupProbe.timeoutSeconds }}
+        periodSeconds: {{ .Values.healthChecks.startupProbe.periodSeconds }}
+        failureThreshold: {{ .Values.healthChecks.startupProbe.failureThreshold }}
+        httpGet:
+          path: {{ .Values.falco.webserver.k8s_healthz_endpoint }}
+          port: {{ .Values.falco.webserver.listen_port }}
+          {{- if .Values.falco.webserver.ssl_enabled }}
+          scheme: HTTPS
+          {{- end }}
       livenessProbe:
         initialDelaySeconds: {{ .Values.healthChecks.livenessProbe.initialDelaySeconds }}
         timeoutSeconds: {{ .Values.healthChecks.livenessProbe.timeoutSeconds }}
         periodSeconds: {{ .Values.healthChecks.livenessProbe.periodSeconds }}
+        failureThreshold: {{ .Values.healthChecks.livenessProbe.failureThreshold }}
         httpGet:
           path: {{ .Values.falco.webserver.k8s_healthz_endpoint }}
           port: {{ .Values.falco.webserver.listen_port }}
@@ -113,6 +125,7 @@ spec:
         initialDelaySeconds: {{ .Values.healthChecks.readinessProbe.initialDelaySeconds }}
         timeoutSeconds: {{ .Values.healthChecks.readinessProbe.timeoutSeconds }}
         periodSeconds: {{ .Values.healthChecks.readinessProbe.periodSeconds }}
+        failureThreshold: {{ .Values.healthChecks.readinessProbe.failureThreshold }}
         httpGet:
           path: {{ .Values.falco.webserver.k8s_healthz_endpoint }}
           port: {{ .Values.falco.webserver.listen_port }}

--- a/charts/falco/values.yaml
+++ b/charts/falco/values.yaml
@@ -112,20 +112,33 @@ tolerations:
 
 # -- Parameters used
 healthChecks:
+  startupProbe:
+    # -- Tells the kubelet that it should wait X seconds before performing the first probe.
+    initialDelaySeconds: 3
+    # -- Number of seconds after which the probe times out.
+    timeoutSeconds: 5
+    # -- Specifies that the kubelet should perform the check every x seconds.
+    periodSeconds: 5
+    # -- failureThreshold * periodSeconds is the max startup time
+    failureThreshold: 20
   livenessProbe:
     # -- Tells the kubelet that it should wait X seconds before performing the first probe.
-    initialDelaySeconds: 60
+    initialDelaySeconds: 0
     # -- Number of seconds after which the probe times out.
     timeoutSeconds: 5
     # -- Specifies that the kubelet should perform the check every x seconds.
     periodSeconds: 15
+    # -- Number of times in a row before the check fails
+    failureThreshold: 3
   readinessProbe:
     # -- Tells the kubelet that it should wait X seconds before performing the first probe.
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     # -- Number of seconds after which the probe times out.
     timeoutSeconds: 5
     # -- Specifies that the kubelet should perform the check every x seconds.
     periodSeconds: 15
+    # -- Number of times in a row before the check fails
+    failureThreshold: 3
 
 # -- Attach the Falco process to a tty inside the container. Needed to flush Falco logs as soon as they are emitted.
 # Set it to "true" when you need the Falco logs to be immediately displayed.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-chart


**What this PR does / why we need it**:

Replace initialDelaySeconds in liveness/readiness probes by startupProbe for quicker startup

**Special notes for your reviewer**:


**Checklist**
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
