### PR TITLE
fix redis customConfig type

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.12.1
+
+- fix Redis customConfig type
+
 ## 0.12.0
 
 - Allow specifying folder annotation for grafana dashboards

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.31.1
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.12.0
+version: 0.12.1
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/README.md
+++ b/charts/falcosidekick/README.md
@@ -705,7 +705,7 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | webui.priorityClassName | string | `""` | Name of the priority class to be used by the Web UI pods, priority class needs to be created beforehand |
 | webui.redis.affinity | object | `{}` | Affinity for the Web UI Redis pods |
 | webui.redis.customAnnotations | object | `{}` | custom annotations to add to all resources |
-| webui.redis.customConfig | object | `{}` | List of Custom config overrides for Redis |
+| webui.redis.customConfig | list | `[]` | List of Custom config overrides for Redis |
 | webui.redis.customLabels | object | `{}` | custom labels to add to all resources |
 | webui.redis.enabled | bool | `true` | Is mutually exclusive with webui.externalRedis.enabled |
 | webui.redis.existingSecret | string | `""` | Existing secret with configuration |

--- a/charts/falcosidekick/values.yaml
+++ b/charts/falcosidekick/values.yaml
@@ -1349,7 +1349,7 @@ webui:
       pullPolicy: IfNotPresent
 
     # -- List of Custom config overrides for Redis
-    customConfig: {}
+    customConfig: []
       # - maxmemory-policy allkeys-lfu
       # - maxmemory 4096mb
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind chart-release

**Any specific area of the project related to this PR?**

/area falcosidekick-chart

**What this PR does / why we need it**:

Fix the type of redis customConfig

**Which issue(s) this PR fixes**:

level=INFO msg="warning: cannot overwrite table with non table for falco.falcosidekick.webui.redis.customConfig (map[])"

**Special notes for your reviewer**:

**Checklist**
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated