### PR TITLE
wip: ADD introducing the "splitFiles" feature from feature request issue #1018

### DIFF
--- a/charts/falco/templates/pod-template.tpl
+++ b/charts/falco/templates/pod-template.tpl
@@ -188,8 +188,18 @@ spec:
           name: falco-yaml
           subPath: falco.yaml
         {{- if .Values.customRules }}
+        {{- if .Values.customRules.splitFiles.enabled }}
+        {{- $root := . -}}
+        {{- range $file, $content :=  .Values.customRules.splitFiles.files }}
+        {{- $baseName := trimSuffix ".yaml" $file | replace "." "-" | replace "_" "-"}}
+        - mountPath: /etc/falco/rules.d/{{ $file }}
+          name: {{ include "falco.fullname" $root }}-{{ $baseName}}-rules-volume
+          subPath: {{ $file }}
+        {{- end }}
+        {{- else }}
         - mountPath: /etc/falco/rules.d
           name: rules-volume
+        {{- end }}
         {{- end }}
         {{- if or .Values.certs.existingSecret (and .Values.certs.server.key .Values.certs.server.crt .Values.certs.ca.crt) }}
         - mountPath: /etc/falco/certs
@@ -278,9 +288,19 @@ spec:
         - key: falco.yaml
           path: falco.yaml
     {{- if .Values.customRules }}
+    {{- if .Values.customRules.splitFiles.enabled }}
+    {{- $root := . -}}
+    {{- range $file, $content :=  .Values.customRules.splitFiles.files }}
+    {{- $baseName := trimSuffix ".yaml" $file | replace "." "-" | replace "_" "-"}}
+    - name: {{ include "falco.fullname" $root }}-{{ $baseName}}-rules-volume
+      configMap:
+        name: {{ include "falco.fullname" $root }}-{{ $baseName}}-rules
+    {{- end }}
+    {{- else }}
     - name: rules-volume
       configMap:
         name: {{ include "falco.fullname" . }}-rules
+    {{- end }}
     {{- end }}
     {{- if or .Values.certs.existingSecret (and .Values.certs.server.key .Values.certs.server.crt .Values.certs.ca.crt) }}
     - name: certs-volume

--- a/charts/falco/templates/rules-configmap.yaml
+++ b/charts/falco/templates/rules-configmap.yaml
@@ -1,4 +1,21 @@
 {{- if .Values.customRules }}
+{{- if .Values.customRules.splitFiles.enabled }}
+{{- $root := . -}}
+{{- range $file, $content := .Values.customRules.splitFiles.files }}
+{{- $baseName := trimSuffix ".yaml" $file | replace "." "-" | replace "_" "-"}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "falco.fullname" $root }}-{{ $baseName}}-rules
+  namespace: {{ include "falco.namespace" $root }}
+  labels:
+    {{- include "falco.labels" $root | nindent 4 }}
+data:
+  {{ $file }}: |-
+{{ $content | indent 4}}
+---
+{{- end }}
+{{- else }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,5 +27,6 @@ data:
 {{- range $file, $content :=  .Values.customRules }}
   {{ $file }}: |-
 {{ $content | indent 4}}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/falco/values.yaml
+++ b/charts/falco/values.yaml
@@ -484,6 +484,19 @@ certs:
 
 # -- Third party rules enabled for Falco. More info on the dedicated section in README.md file.
 customRules: {}
+  # When activated, splitFiles mechanism allow to generate one configmap per rules files instead of concatenating it in a single configmap.
+  #splitFiles:
+  #  enabled: true
+  #  files:
+  #
+  # Example:
+  # splitFiles:
+  #   enabled: true
+  #   files:
+  #     rules-traefik.yaml: |-
+  #     #   [ rule body ]
+  #     rules-nginx.yaml: |-
+  #     #   [ rule body ]
   # Although Falco comes with a nice default rule set for detecting weird
   # behavior in containers, our users are going to customize the run-time
   # security rule sets or policies for the specific container images and


### PR DESCRIPTION
ADD introducing the "splitFiles" feature from feature request issue #1018

Ref: https://github.com/falcosecurity/charts/issues/1018

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

This implements the "splitFiles" feature in the chart, allowing to generate 1 configmap per rules files provided in the "customRules" section instead of merging all rules files in a single configMap which can be harder to maintain.

See https://github.com/falcosecurity/charts/issues/1018

**Which issue(s) this PR fixes**:

Fixes #1018

**Special notes for your reviewer**:

Pull requests #1019 closed due to some misconfig (dco signed off + wrong author)

**Checklist**

- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] CHANGELOG.md updated
