### PR TITLE
CHANGE introducing the change of "falcoctl" configmap to secret object as requested in feature request issue #977

### DIFF
--- a/charts/falco/templates/falcoctl-secret.yaml
+++ b/charts/falco/templates/falcoctl-secret.yaml
@@ -1,12 +1,13 @@
 {{- if or .Values.falcoctl.artifact.install.enabled .Values.falcoctl.artifact.follow.enabled }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ include "falco.fullname" . }}-falcoctl
   namespace: {{ include "falco.namespace" . }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
-data:
+type: Opaque
+stringData:
   falcoctl.yaml: |-
     {{- include "k8smeta.configuration" . -}}
     {{- include "falco.containerPlugin" . -}}

--- a/charts/falco/templates/pod-template.tpl
+++ b/charts/falco/templates/pod-template.tpl
@@ -266,8 +266,8 @@ spec:
         path: /proc
     {{- end }}
     - name: falcoctl-config-volume
-      configMap: 
-        name: {{ include "falco.fullname" . }}-falcoctl
+      secret: 
+        secretName: {{ include "falco.fullname" . }}-falcoctl
         items:
           - key: falcoctl.yaml
             path: falcoctl.yaml


### PR DESCRIPTION
CHANGE introducing the change of "falcoctl" configmap to secret object as requested in feature request issue #977
TODO: think about replacing the uggly "stringData" by something more like chaing " | b64enc" in data section

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area falco-chart

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #977

**Special notes for your reviewer**:


**Checklist**

- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] CHANGELOG.md updated