### PR TITLE
ci(.github): auto-run managed-chart guard and post redirect comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 2. Please label this pull request according to what type of issue you are addressing.
 3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
 
-Chart changes for directories listed in [.github/managed-charts.yaml](../.github/managed-charts.yaml) must be authored in the source repository. Non-automation PRs changing those directories are blocked.
+⚠ Some charts in this repository are **managed**: owned by their source repositories and synced here by Poiana. Direct edits to managed charts will be blocked by the "Guard Managed Charts" check; please open changes against the appropriate source repo. See [.github/managed-charts.yaml](../.github/managed-charts.yaml) for the list of managed charts and their source mapping.
 -->
 
 **What type of PR is this?**

--- a/.github/workflows/managed-charts.yml
+++ b/.github/workflows/managed-charts.yml
@@ -1,7 +1,7 @@
 name: Guard Managed Charts
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
 
@@ -13,18 +13,12 @@ jobs:
 
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
 
     steps:
       - name: Skip Poiana
         if: github.event.pull_request.user.login == 'poiana'
         run: echo "Managed chart guard skipped for Poiana."
-
-      - name: Checkout
-        if: github.event.pull_request.user.login != 'poiana'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
 
       - name: Checkout base guard config
         if: github.event.pull_request.user.login != 'poiana'
@@ -35,22 +29,47 @@ jobs:
           sparse-checkout: .github/managed-charts.yaml
           persist-credentials: false
 
-      - name: Select guard config
-        id: managed-chart-filters
-        if: github.event.pull_request.user.login != 'poiana'
-        run: |
-          if [[ -f base/.github/managed-charts.yaml ]]; then
-            echo "path=base/.github/managed-charts.yaml" >> "${GITHUB_OUTPUT}"
-          else
-            echo "path=.github/managed-charts.yaml" >> "${GITHUB_OUTPUT}"
-          fi
-
       - name: Detect managed chart changes
         id: managed-chart-changes
         if: github.event.pull_request.user.login != 'poiana'
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
-          filters: ${{ steps.managed-chart-filters.outputs.path }}
+          filters: base/.github/managed-charts.yaml
+
+      - name: Comment redirect on managed chart change
+        if: github.event.pull_request.user.login != 'poiana' && steps.managed-chart-changes.outputs.changes != '[]'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const marker = '<!-- managed-charts-guard -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user.login;
+            const body = [
+              marker,
+              `Hi @${author} 👋 thanks for the PR!`,
+              '',
+              '> [!IMPORTANT]',
+              '> The files you changed belong to a **managed chart**. Direct edits to managed charts in this repository are not accepted, and this PR will be blocked by the **Guard Managed Charts** check.',
+              '',
+              'Managed charts are owned by their source repositories and synced into this repo by Poiana. Please open this change against the appropriate source repository instead.',
+              '',
+              `- Chart-to-source mapping: [.github/managed-charts.yaml](https://github.com/${owner}/${repo}/blob/master/.github/managed-charts.yaml)`,
+              `- Contributing guidelines: [CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/master/CONTRIBUTING.md)`,
+              '',
+              '🙏',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number,
+            });
+            const existing = comments.find(c => c.body?.startsWith(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
 
       - name: Block direct managed chart changes
         if: github.event.pull_request.user.login != 'poiana' && steps.managed-chart-changes.outputs.changes != '[]'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"

Chart changes for directories listed in [.github/managed-charts.yaml](../.github/managed-charts.yaml) must be authored in the source repository. Non-automation PRs changing those directories are blocked.
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area falco-chart

> /area falcosidekick-chart

> /area falco-talon-chart

> /area event-generator-chart

> /area k8s-metacollector-chart

> /area falco-operator-chart

/area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Extends the existing `Guard Managed Charts` workflow so it does two things on every PR:

1. Posts (or updates) a sticky comment on the PR explaining that the modified files belong to a managed chart, that direct edits to managed charts in this repo are not accepted, and that the PR will be blocked by the guard. The comment points the contributor at `.github/managed-charts.yaml` (chart-to-source-repo mapping) and `CONTRIBUTING.md` (policy).
2. Continues to fail the job with the same error message as before, so the existing block behavior is unchanged.

Also updates `.github/PULL_REQUEST_TEMPLATE.md` so that contributors composing a PR see the managed-chart policy upfront, with the names of the managed charts inlined (instead of having to click through to the YAML) and an explicit pointer to the `Guard Managed Charts` check name. This keeps the template ↔ bot comment ↔ failing check messaging consistent so a contributor whose PR is caught by the guard sees the same wording in all three places.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] CHANGELOG.md updated
