### PR TITLE
[falcosidekick] Add Gateway API HTTPRoute support

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.14.0
+
+- Add Gateway API `HTTPRoute` support for Falcosidekick and Falcosidekick UI as an alternative to Ingress
+
 ## 0.13.1
 
 - Update curl image used in test by the official multi-arch image

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.31.1
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.13.1
+version: 0.14.0
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/README.md
+++ b/charts/falcosidekick/README.md
@@ -620,6 +620,17 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | grafana.dashboards.configMaps.falcosidekick.name | string | `"falcosidekick-grafana-dashboard"` | name specifies the name for the configmap. |
 | grafana.dashboards.configMaps.falcosidekick.namespace | string | `""` | namespace specifies the namespace for the configmap. |
 | grafana.dashboards.enabled | bool | `false` | enabled specifies whether the dashboards should be deployed. |
+| httproute.additionalRules | list | `[]` | additionalRules (templated) prepends custom rules to the route |
+| httproute.annotations | object | `{}` | HTTPRoute annotations |
+| httproute.apiVersion | string | `""` | HTTPRoute apiVersion (defaults to "gateway.networking.k8s.io/v1" when empty) |
+| httproute.enabled | bool | `false` | Whether to create the HTTPRoute (Gateway API). Requires the Gateway API CRDs to be installed in the cluster |
+| httproute.filters | list | `[]` | filters applied to requests that match this rule |
+| httproute.hostnames | list | `[]` | hostnames (templated) that should match against the HTTP Host header to select this HTTPRoute |
+| httproute.httpsRedirect | bool | `false` | httpsRedirect adds a filter to redirect HTTP to HTTPS (301). When enabled, matches and filters are ignored. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/ |
+| httproute.kind | string | `""` | HTTPRoute kind (defaults to "HTTPRoute" when empty) |
+| httproute.labels | object | `{}` | HTTPRoute additional labels |
+| httproute.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | matches define conditions used for matching the rule against incoming HTTP requests |
+| httproute.parentRefs | list | `[]` | parentRefs references the Gateways this HTTPRoute should be attached to |
 | image | object | `{"pullPolicy":"IfNotPresent","registry":"docker.io","repository":"falcosecurity/falcosidekick","tag":"2.32.0"}` | number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10) revisionHistoryLimit: 1 |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | image.registry | string | `"docker.io"` | The image registry to pull from |
@@ -683,6 +694,17 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | webui.externalRedis.password | string | `""` | Set the password of the external Redis |
 | webui.externalRedis.port | int | `6379` | The port of the external Redis database with RediSearch > v2 |
 | webui.externalRedis.url | string | `""` | The URL of the external Redis database with RediSearch > v2 |
+| webui.httproute.additionalRules | list | `[]` | additionalRules (templated) prepends custom rules to the route |
+| webui.httproute.annotations | object | `{}` | Web UI HTTPRoute annotations |
+| webui.httproute.apiVersion | string | `""` | HTTPRoute apiVersion (defaults to "gateway.networking.k8s.io/v1" when empty) |
+| webui.httproute.enabled | bool | `false` | Whether to create the Web UI HTTPRoute (Gateway API). Requires the Gateway API CRDs to be installed in the cluster |
+| webui.httproute.filters | list | `[]` | filters applied to requests that match this rule |
+| webui.httproute.hostnames | list | `[]` | hostnames (templated) that should match against the HTTP Host header to select this HTTPRoute |
+| webui.httproute.httpsRedirect | bool | `false` | httpsRedirect adds a filter to redirect HTTP to HTTPS (301). When enabled, matches and filters are ignored |
+| webui.httproute.kind | string | `""` | HTTPRoute kind (defaults to "HTTPRoute" when empty) |
+| webui.httproute.labels | object | `{}` | Web UI HTTPRoute additional labels |
+| webui.httproute.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | matches define conditions used for matching the rule against incoming HTTP requests |
+| webui.httproute.parentRefs | list | `[]` | parentRefs references the Gateways this HTTPRoute should be attached to |
 | webui.image.pullPolicy | string | `"IfNotPresent"` | The web UI image pull policy |
 | webui.image.registry | string | `"docker.io"` | The web UI image registry to pull from |
 | webui.image.repository | string | `"falcosecurity/falcosidekick-ui"` | The web UI image repository to pull from |

--- a/charts/falcosidekick/templates/NOTES.txt
+++ b/charts/falcosidekick/templates/NOTES.txt
@@ -5,6 +5,10 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
+{{- else if .Values.httproute.enabled }}
+{{- range .Values.httproute.hostnames }}
+  http{{ if $.Values.httproute.httpsRedirect }}s{{ end }}://{{ tpl . $ }}/
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "falcosidekick.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
@@ -23,6 +27,10 @@
 {{- if .Values.webui.ingress.enabled }}
 {{- range $host := .Values.webui.ingress.hosts }}
   http{{ if $.Values.webui.ingress.tls }}s{{ end }}://{{ $host.host }}{{ index $host.paths 0 }}
+{{- end }}
+{{- else if .Values.webui.httproute.enabled }}
+{{- range .Values.webui.httproute.hostnames }}
+  http{{ if $.Values.webui.httproute.httpsRedirect }}s{{ end }}://{{ tpl . $ }}/
 {{- end }}
 {{- else if contains "NodePort" .Values.webui.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "falcosidekick.fullname" . }})-ui

--- a/charts/falcosidekick/templates/httproute-ui.yaml
+++ b/charts/falcosidekick/templates/httproute-ui.yaml
@@ -1,0 +1,58 @@
+{{- if and .Values.webui.enabled .Values.webui.httproute.enabled -}}
+{{- $fullName := include "falcosidekick.fullname" . -}}
+{{- $route := .Values.webui.httproute -}}
+---
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ $fullName }}-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "falcosidekick.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+    {{- with .Values.webui.customLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.webui.customAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $route.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.additionalRules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}-ui
+          port: {{ .Values.webui.service.port }}
+      {{- with $route.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/falcosidekick/templates/httproute.yaml
+++ b/charts/falcosidekick/templates/httproute.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.httproute.enabled -}}
+{{- $fullName := include "falcosidekick.fullname" . -}}
+{{- $route := .Values.httproute -}}
+---
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "falcosidekick.labels" . | nindent 4 }}
+    app.kubernetes.io/component: core
+    {{- with .Values.customLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.customAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $route.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.additionalRules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ .Values.service.port }}
+      {{- with $route.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/falcosidekick/values.yaml
+++ b/charts/falcosidekick/values.yaml
@@ -1172,6 +1172,36 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+httproute:
+  # -- Whether to create the HTTPRoute (Gateway API). Requires the Gateway API CRDs to be installed in the cluster
+  enabled: false
+  # -- HTTPRoute apiVersion (defaults to "gateway.networking.k8s.io/v1" when empty)
+  apiVersion: ""
+  # -- HTTPRoute kind (defaults to "HTTPRoute" when empty)
+  kind: ""
+  # -- HTTPRoute annotations
+  annotations: {}
+  # -- HTTPRoute additional labels
+  labels: {}
+  # -- parentRefs references the Gateways this HTTPRoute should be attached to
+  parentRefs: []
+    # - name: my-gateway
+    #   sectionName: http
+  # -- hostnames (templated) that should match against the HTTP Host header to select this HTTPRoute
+  hostnames: []
+    # - falcosidekick.local
+  # -- matches define conditions used for matching the rule against incoming HTTP requests
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+  # -- filters applied to requests that match this rule
+  filters: []
+  # -- additionalRules (templated) prepends custom rules to the route
+  additionalRules: []
+  # -- httpsRedirect adds a filter to redirect HTTP to HTTPS (301). When enabled, matches and filters are ignored. Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
+  httpsRedirect: false
+
 # -- The resources for falcosdekick pods
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -1310,6 +1340,36 @@ webui:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+
+  httproute:
+    # -- Whether to create the Web UI HTTPRoute (Gateway API). Requires the Gateway API CRDs to be installed in the cluster
+    enabled: false
+    # -- HTTPRoute apiVersion (defaults to "gateway.networking.k8s.io/v1" when empty)
+    apiVersion: ""
+    # -- HTTPRoute kind (defaults to "HTTPRoute" when empty)
+    kind: ""
+    # --  Web UI HTTPRoute annotations
+    annotations: {}
+    # --  Web UI HTTPRoute additional labels
+    labels: {}
+    # --  parentRefs references the Gateways this HTTPRoute should be attached to
+    parentRefs: []
+      # - name: my-gateway
+      #   sectionName: http
+    # --  hostnames (templated) that should match against the HTTP Host header to select this HTTPRoute
+    hostnames: []
+      # - falcosidekick-ui.local
+    # --  matches define conditions used for matching the rule against incoming HTTP requests
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # --  filters applied to requests that match this rule
+    filters: []
+    # --  additionalRules (templated) prepends custom rules to the route
+    additionalRules: []
+    # --  httpsRedirect adds a filter to redirect HTTP to HTTPS (301). When enabled, matches and filters are ignored
+    httpsRedirect: false
   # --  The resources for the web UI pods
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Add Gateway API `HTTPRoute` support to the falcosidekick chart for both the core service and the Web UI, as an alternative to the existing Ingress resources. This follows the ingress-nginx retirement and the migration toward Gateway API described in #962.

- New `templates/httproute.yaml` (core) gated by `httproute.enabled`
- New `templates/httproute-ui.yaml` (Web UI) gated by `webui.httproute.enabled`
- Mirrors the existing `ingress.yaml` / `ingress-ui.yaml` structure; both default to `false`, so existing installs are unaffected
- Supports `parentRefs`, `hostnames` (templated), `matches`, `filters`, `additionalRules`, `httpsRedirect`, and `apiVersion` / `kind` overrides

Validation (local):
- `helm lint charts/falcosidekick` → 0 chart(s) failed
- `helm template` with defaults → no HTTPRoute rendered (disabled by default)
- core enabled → backend `<release>-falcosidekick:2801`
- Web UI enabled → backend `<release>-falcosidekick-ui:2802`
- `httpsRedirect=true` → RequestRedirect (301) filter only
- `make docs-falcosidekick` → README regenerated (helm-docs v1.11.0)

Chart version bumped `0.13.1` → `0.14.0`, CHANGELOG updated.

closes #962

/kind feature
/area falcosidekick-chart
