### PR TITLE
fix(falco-talon): fix missing namespace in the Secret metadata

### DIFF
--- a/charts/falco-talon/CHANGELOG.md
+++ b/charts/falco-talon/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Talon Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## 0.4.1 - 2026-06-15
+
+- fix missing namespace in the Secret metadata
+
 ## 0.4.0 - 2025-05-02
 
 - Allow specifying folder annotation for grafana dashboards

--- a/charts/falco-talon/Chart.yaml
+++ b/charts/falco-talon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.3.0
 description: React to the events from Falco
 name: falco-talon
-version: 0.4.0
+version: 0.4.1
 keywords:
   - falco
   - monitoring

--- a/charts/falco-talon/templates/secrets.yaml
+++ b/charts/falco-talon/templates/secrets.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "falco-talon.name" . }}-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "falco-talon.labels" . | nindent 4 }}
 stringData:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area falco-talon-chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The Secret does not set a namespace. As a result, when the manifests are rendered and then applied, the Secret is created without a namespace and the Pod cannot reference it, so the Pod fails to start.
This PR sets the namespace on the Secret, which resolves the issue.
For more details, refer to #1028.

**Which issue(s) this PR fixes**:

Fixes #1028


**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated
