### PR TITLE
sync(charts/falco-operator): v0.3.0

### DIFF
--- a/charts/falco-operator/CHANGELOG.md
+++ b/charts/falco-operator/CHANGELOG.md
@@ -5,6 +5,12 @@ release numbering uses [semantic versioning](http://semver.org).
 
 ## Unreleased
 
+## v0.3.0
+
+* Update the default Falco Operator image tag to `0.4.0`.
+* Add `excludedLabels` to stop propagating tracking labels used by external tools onto operator-generated resources, preventing repeated removal/recreation of cluster-scoped resources.
+* Add `dnsPolicy` and `dnsConfig` support for the operator pod.
+
 ## v0.2.0
 
 * Update the default Falco Operator image tag to `0.3.0`.

--- a/charts/falco-operator/Chart.yaml
+++ b/charts/falco-operator/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
   - name: The Falco Authors
     email: cncf-falco-dev@lists.cncf.io
 type: application
-version: 0.2.0
-appVersion: "0.3.0"
+version: 0.3.0
+appVersion: "0.4.0"

--- a/charts/falco-operator/README.md
+++ b/charts/falco-operator/README.md
@@ -41,13 +41,16 @@ helm uninstall falco-operator --namespace falco-operator
 
 ## Configuration
 
-The following table lists the configurable parameters of the falco-operator chart v0.2.0 and their default values. See [values.yaml](values.yaml) for the full list.
+The following table lists the configurable parameters of the falco-operator chart v0.3.0 and their default values. See [values.yaml](values.yaml) for the full list.
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules |
+| dnsConfig | object | `{}` | Pod DNS config. Requires dnsPolicy to be set to None to take full effect. |
+| dnsPolicy | string | `""` | Pod DNS policy. One of ClusterFirst, ClusterFirstWithHostNet, Default or None. |
+| excludedLabels | list | `[]` | Label keys that must NOT be propagated onto operator-generated resources. Supports the '*' wildcard (e.g. `kustomize.toolkit.fluxcd.io/*`). |
 | extraArgs | list | `[]` | Additional CLI arguments passed to the operator binary |
 | extraEnv | list | `[]` | Extra environment variables |
 | extraObjects | list | `[]` | Array of extra Kubernetes manifests to deploy alongside the operator. Each entry is rendered with `tpl`, so Helm templating (e.g. `{{ .Release.Name }}`) is supported within values. |

--- a/charts/falco-operator/templates/deployment.yaml
+++ b/charts/falco-operator/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
             - /usr/bin/manager
           args:
             - --health-probe-bind-address=:8081
+            {{- range .Values.excludedLabels }}
+            - --excluded-labels={{ . }}
+            {{- end }}
             {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -101,5 +104,12 @@ spec:
       {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: 10

--- a/charts/falco-operator/values.yaml
+++ b/charts/falco-operator/values.yaml
@@ -101,6 +101,13 @@ volumes: []
 # -- Additional volume mounts
 volumeMounts: []
 
+# -- Label keys that must NOT be propagated onto operator-generated resources.
+# Supports the '*' wildcard (e.g. `kustomize.toolkit.fluxcd.io/*`).
+excludedLabels: []
+  # - argocd.argoproj.io/instance
+  # - kustomize.toolkit.fluxcd.io/name
+  # - kustomize.toolkit.fluxcd.io/namespace
+
 # -- Additional CLI arguments passed to the operator binary
 extraArgs: []
   # - --metrics-bind-address=:8443
@@ -131,6 +138,19 @@ topologySpreadConstraints: []
 
 # -- Priority class name
 priorityClassName: ""
+
+# -- Pod DNS policy. One of ClusterFirst, ClusterFirstWithHostNet, Default or None.
+dnsPolicy: ""
+
+# -- Pod DNS config. Requires dnsPolicy to be set to None to take full effect.
+dnsConfig: {}
+  # nameservers:
+  #   - 1.1.1.1
+  # searches:
+  #   - ns.svc.cluster.local
+  # options:
+  #   - name: ndots
+  #     value: "2"
 
 # -- Array of extra Kubernetes manifests to deploy alongside the operator. Each
 # entry is rendered with `tpl`, so Helm templating (e.g. `{{ .Release.Name }}`)


### PR DESCRIPTION
**What type of PR is this?**

/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-operator-chart

**What this PR does / why we need it**:

Syncs the falco-operator Helm chart from its source repository.

Source chart: https://github.com/falcosecurity/falco-operator/tree/main/chart/falco-operator
Source commit: https://github.com/falcosecurity/falco-operator/commit/bd0a3d615cbb9a697f13e6842a0f2b3f43394a44

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Generated by the sync-charts ProwJob. Do not edit this PR directly; change the source chart instead.


**Checklist**
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated