### PR TITLE
sync(charts/falco-operator): v0.3.1

### DIFF
--- a/charts/falco-operator/CHANGELOG.md
+++ b/charts/falco-operator/CHANGELOG.md
@@ -5,6 +5,10 @@ release numbering uses [semantic versioning](http://semver.org).
 
 ## Unreleased
 
+## v0.3.1
+
+* Update the default Falco Operator image tag to `0.4.1`.
+
 ## v0.3.0
 
 * Update the default Falco Operator image tag to `0.4.0`.

--- a/charts/falco-operator/Chart.yaml
+++ b/charts/falco-operator/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
   - name: The Falco Authors
     email: cncf-falco-dev@lists.cncf.io
 type: application
-version: 0.3.0
-appVersion: "0.4.0"
+version: 0.3.1
+appVersion: "0.4.1"

--- a/charts/falco-operator/README.md
+++ b/charts/falco-operator/README.md
@@ -41,7 +41,7 @@ helm uninstall falco-operator --namespace falco-operator
 
 ## Configuration
 
-The following table lists the configurable parameters of the falco-operator chart v0.3.0 and their default values. See [values.yaml](values.yaml) for the full list.
+The following table lists the configurable parameters of the falco-operator chart v0.3.1 and their default values. See [values.yaml](values.yaml) for the full list.
 
 ## Values
 


### PR DESCRIPTION
**What type of PR is this?**

/kind chart-release

**Any specific area of the project related to this PR?**

/area falco-operator-chart

**What this PR does / why we need it**:

Syncs the falco-operator Helm chart from its source repository.

Source chart: https://github.com/falcosecurity/falco-operator/tree/main/chart/falco-operator
Source commit: https://github.com/falcosecurity/falco-operator/commit/45222e272650d44f7688222f7aeb3c0bf1a0688b

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Generated by the sync-charts ProwJob. Do not edit this PR directly; change the source chart instead.


**Checklist**
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated