### PR TITLE
feat: introducing default networkPolicy using "defaultNetworkPolicy" dedicated values section

### DIFF
--- a/charts/falcosidekick/CHANGELOG.md
+++ b/charts/falcosidekick/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 Before release 0.1.20, the helm chart can be found in `falcosidekick` [repository](https://github.com/falcosecurity/falcosidekick/tree/master/deploy/helm/falcosidekick).
 
+## 0.15.0
+
+- Add default networkPolicy `defaultNetworkPolicy` support for Falcosidekick and Falcosidekick UI components
+
 ## 0.14.0
 
 - Add Gateway API `HTTPRoute` support for Falcosidekick and Falcosidekick UI as an alternative to Ingress

--- a/charts/falcosidekick/Chart.yaml
+++ b/charts/falcosidekick/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.31.1
 description: Connect Falco to your ecosystem
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png
 name: falcosidekick
-version: 0.14.0
+version: 0.15.0
 keywords:
   - monitoring
   - security

--- a/charts/falcosidekick/README.gotmpl
+++ b/charts/falcosidekick/README.gotmpl
@@ -185,3 +185,56 @@ You may want to access the `WebUI (Falcosidekick UI)`](https://github.com/falcos
 nginx.ingress.kubernetes.io/rewrite-target: /$2
 nginx.ingress.kubernetes.io/use-regex: "true"
 ```
+
+## Activate default networkPolicy for falcosidekick components
+
+You may want to harden the way falcosidekick is deployed by enabling a default networkPolicy.
+
+Set the `defaultNetworkPolicy.enabled` to `true` to activate the default networkPolicy.
+```yaml
+defaultNetworkPolicy:
+  enabled: true
+```
+
+You can also set additional `webuiIngressNetworkPolicyNamespaceSelector` and `webuiIngressNetworkPolicyPodSelector` values to allow sidekick-ui flows from ingress-controller pods (applicable only if `webui.enabled` and `webui.ingress.enabled` are both set to true ).
+```yaml
+  webuiIngressNetworkPolicyNamespaceSelector:
+    kubernetes.io/metadata.name: dummy-namespace
+  webuiIngressNetworkPolicyPodSelector:
+    app.kubernetes.io/dummykey1: any-dummy-value
+    app.kubernetes.io/dummykey2: another-dummy-value-just-in-case
+```
+
+Full Example with (deprecrated) ingress-nginx below:
+```yaml
+defaultNetworkPolicy:
+  enabled: true
+  webuiIngressNetworkPolicyNamespaceSelector: 
+    kubernetes.io/metadata.name: ingress-nginx
+  webuiIngressNetworkPolicyPodSelector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+[...]
+webui:
+  # -- enable Falcosidekick-UI
+  enabled: true
+  [...]
+  ingress:
+    # -- Whether to create the Web UI ingress
+    enabled: true
+    [...]
+```
+
+Policy behavior depending on values set:
+| defaultNetworkPolicy.enabled | webui.enabled  | webui.ingress.enabled | networkPolicy rendered | sidekick-core                                                           | sidekick-ui                                                   | sidekick-ui-redis ingress                           |
+| ---------------------------- | -------------- | --------------------- | ---------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------- |
+| false                        | (true / false) | (true / false)        | NO                     | none                                                                    | none                                                          | none                                                |
+| true                         | false          | (true / false)        | YES                    | <pre>ingress TCP 2801, TCP 2810</pre><pre>egress UDP 53</pre>           | none                                                          | none                                                |
+| true                         | true           | false                 | YES                    | <pre>ingress TCP 2801, TCP 2810</pre><pre>egress UDP 53, TCP 2802</pre> | <pre>ingress TCP 2802*</pre><pre>egress UDP 53, TCP 6379</pre> | <pre>ingress TCP 6379</pre><pre>egress UDP 53</pre> |
+| true                         | true           | true                  | YES                    | <pre>ingress TCP 2801, TCP 2810</pre><pre>egress UDP 53, TCP 2802</pre> | <pre>ingress TCP 2802**</pre><pre>egress UDP 53, TCP 6379</pre> | <pre>ingress TCP 6379</pre><pre>egress UDP 53</pre> |
+
+*tcp Port 2802 open only for  sidekick-core
+**tcp Port 2802 open for both sidekick-core and ingress
+
+For more details regarding selectors used, look at helm chart template files [network-policy-core.yaml](templates/network-policy-core.yaml), [network-policy-ui.yaml](templates/network-policy-ui.yaml) and [network-policy-redis.yaml](templates/network-policy-redis.yaml).

--- a/charts/falcosidekick/README.md
+++ b/charts/falcosidekick/README.md
@@ -608,6 +608,7 @@ The following table lists the main configurable parameters of the Falcosidekick 
 | config.zincsearch.username | string | `""` | use this username to authenticate to ZincSearch |
 | customAnnotations | object | `{}` | custom annotations to add to all resources |
 | customLabels | object | `{}` | custom labels to add to all resources |
+| defaultNetworkPolicy | object | `{"enabled":false,"webuiIngressNetworkPolicyNamespaceSelector":{},"webuiIngressNetworkPolicyPodSelector":{}}` | Default networkPolicy that comes out of the box with falcosidekick if you don't have any specific needs. |
 | extraVolumeMounts | list | `[]` | Extra volume mounts for sidekick deployment |
 | extraVolumes | list | `[]` | Extra volumes for sidekick deployment |
 | fullnameOverride | string | `""` | Override the name |
@@ -779,3 +780,56 @@ You may want to access the `WebUI (Falcosidekick UI)`](https://github.com/falcos
 nginx.ingress.kubernetes.io/rewrite-target: /$2
 nginx.ingress.kubernetes.io/use-regex: "true"
 ```
+
+## Activate default networkPolicy for falcosidekick components
+
+You may want to harden the way falcosidekick is deployed by enabling a default networkPolicy.
+
+Set the `defaultNetworkPolicy.enabled` to `true` to activate the default networkPolicy.
+```yaml
+defaultNetworkPolicy:
+  enabled: true
+```
+
+You can also set additional `webuiIngressNetworkPolicyNamespaceSelector` and `webuiIngressNetworkPolicyPodSelector` values to allow sidekick-ui flows from ingress-controller pods (applicable only if `webui.enabled` and `webui.ingress.enabled` are both set to true ).
+```yaml
+  webuiIngressNetworkPolicyNamespaceSelector:
+    kubernetes.io/metadata.name: dummy-namespace
+  webuiIngressNetworkPolicyPodSelector:
+    app.kubernetes.io/dummykey1: any-dummy-value
+    app.kubernetes.io/dummykey2: another-dummy-value-just-in-case
+```
+
+Full Example with (deprecrated) ingress-nginx below:
+```yaml
+defaultNetworkPolicy:
+  enabled: true
+  webuiIngressNetworkPolicyNamespaceSelector:
+    kubernetes.io/metadata.name: ingress-nginx
+  webuiIngressNetworkPolicyPodSelector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+[...]
+webui:
+  # -- enable Falcosidekick-UI
+  enabled: true
+  [...]
+  ingress:
+    # -- Whether to create the Web UI ingress
+    enabled: true
+    [...]
+```
+
+Policy behavior depending on values set:
+| defaultNetworkPolicy.enabled | webui.enabled  | webui.ingress.enabled | networkPolicy rendered | sidekick-core                                                           | sidekick-ui                                                   | sidekick-ui-redis ingress                           |
+| ---------------------------- | -------------- | --------------------- | ---------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------- |
+| false                        | (true / false) | (true / false)        | NO                     | none                                                                    | none                                                          | none                                                |
+| true                         | false          | (true / false)        | YES                    | <pre>ingress TCP 2801, TCP 2810</pre><pre>egress UDP 53</pre>           | none                                                          | none                                                |
+| true                         | true           | false                 | YES                    | <pre>ingress TCP 2801, TCP 2810</pre><pre>egress UDP 53, TCP 2802</pre> | <pre>ingress TCP 2802*</pre><pre>egress UDP 53, TCP 6379</pre> | <pre>ingress TCP 6379</pre><pre>egress UDP 53</pre> |
+| true                         | true           | true                  | YES                    | <pre>ingress TCP 2801, TCP 2810</pre><pre>egress UDP 53, TCP 2802</pre> | <pre>ingress TCP 2802**</pre><pre>egress UDP 53, TCP 6379</pre> | <pre>ingress TCP 6379</pre><pre>egress UDP 53</pre> |
+
+*tcp Port 2802 open only for  sidekick-core
+**tcp Port 2802 open for both sidekick-core and ingress
+
+For more details regarding selectors used, look at helm chart template files [network-policy-core.yaml](templates/network-policy-core.yaml), [network-policy-ui.yaml](templates/network-policy-ui.yaml) and [network-policy-redis.yaml](templates/network-policy-redis.yaml).

--- a/charts/falcosidekick/templates/network-policy-core.yaml
+++ b/charts/falcosidekick/templates/network-policy-core.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.defaultNetworkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "falcosidekick.fullname" . }}-core-network-policy
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: core
+      app.kubernetes.io/instance: falco
+      app.kubernetes.io/name: falcosidekick
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Accept Traffic on ports 2801 and 2810 from falco
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: falco
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: falco
+              app.kubernetes.io/name: falco
+          podSelector:
+      ports:
+        # http-notls
+        - port: 2801
+          protocol: TCP
+        # http-notls
+        - port: 2810
+          protocol: TCP
+  egress:
+    # Allow kube-dns resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+    {{- if .Values.webui.enabled }}
+    # Allow sending POST to sidekick-ui to ingest data
+    - to:
+        - podSelector:
+            matchLabels:
+             app.kubernetes.io/component: ui
+             app.kubernetes.io/instance: falco
+             app.kubernetes.io/name: falcosidekick
+      ports:
+        # sidekick-ui
+        - port: 2802
+          protocol: TCP
+    {{- end -}}
+{{- end -}}

--- a/charts/falcosidekick/templates/network-policy-redis.yaml
+++ b/charts/falcosidekick/templates/network-policy-redis.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.defaultNetworkPolicy.enabled -}}
+{{- if .Values.webui.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "falcosidekick.fullname" . }}-ui-redis-network-policy
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: ui-redis
+      app.kubernetes.io/instance: falco
+      app.kubernetes.io/name: falcosidekick
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Accept Traffic on REDIS port 6379 from falcosidekick-ui
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: falco
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: ui
+              app.kubernetes.io/instance: falco
+              app.kubernetes.io/name: falcosidekick
+          podSelector:
+      ports:
+        - port: 6379
+          protocol: TCP
+  egress:
+    # Allow kube-dns resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+{{- end -}}
+{{- end -}}

--- a/charts/falcosidekick/templates/network-policy-ui.yaml
+++ b/charts/falcosidekick/templates/network-policy-ui.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.defaultNetworkPolicy.enabled -}}
+{{- if .Values.webui.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "falcosidekick.fullname" . }}-ui-network-policy
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: ui
+      app.kubernetes.io/instance: falco
+      app.kubernetes.io/name: falcosidekick
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Accept Traffic on port 2802 from falcosidekick-core
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: core
+              app.kubernetes.io/instance: falco
+              app.kubernetes.io/name: falcosidekick
+      ports:
+        - port: 2802
+          protocol: TCP
+  egress:
+    # Allow Traffic on REDIS port 6379
+    - to:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/component: ui-redis
+            app.kubernetes.io/instance: falco
+            app.kubernetes.io/name: falcosidekick
+      ports:
+        - port: 6379
+          protocol: TCP
+    # Allow kube-dns resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+{{- if .Values.webui.ingress.enabled }}
+---
+{{- if or (.Values.defaultNetworkPolicy.webuiIngressNetworkPolicyNamespaceSelector) (.Values.defaultNetworkPolicy.webuiIngressNetworkPolicyPodSelector) }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "falcosidekick.fullname" . }}-ui-network-policy-webui-ingress
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: ui
+      app.kubernetes.io/instance: falco
+      app.kubernetes.io/name: falcosidekick
+  policyTypes:
+    - Ingress
+  ingress:
+    # Accept Traffic on port 2802 from ingress controller
+    - from:
+        {{- if and (.Values.defaultNetworkPolicy.webuiIngressNetworkPolicyNamespaceSelector) (.Values.defaultNetworkPolicy.webuiIngressNetworkPolicyPodSelector) }}
+        - namespaceSelector:
+            matchLabels:
+              {{- with .Values.defaultNetworkPolicy.webuiIngressNetworkPolicyNamespaceSelector }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
+          podSelector:
+            matchLabels:
+              {{- with .Values.defaultNetworkPolicy.webuiIngressNetworkPolicyPodSelector }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
+        {{- end }}
+        {{- if and (.Values.defaultNetworkPolicy.webuiIngressNetworkPolicyNamespaceSelector) (not .Values.defaultNetworkPolicy.webuiIngressNetworkPolicyPodSelector) }}
+        - namespaceSelector:
+            matchLabels:
+              {{- with .Values.defaultNetworkPolicy.webuiIngressNetworkPolicyNamespaceSelector }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
+        {{- end }}
+        {{- if and (.Values.defaultNetworkPolicy.webuiIngressNetworkPolicyPodSelector) (not .Values.defaultNetworkPolicy.webuiIngressNetworkPolicyNamespaceSelector) }}
+        - podSelector:
+            matchLabels:
+              {{- with .Values.defaultNetworkPolicy.webuiIngressNetworkPolicyPodSelector }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
+        {{- end }}
+      ports:
+        - port: 2802
+          protocol: TCP
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/falcosidekick/values.yaml
+++ b/charts/falcosidekick/values.yaml
@@ -1172,6 +1172,20 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# -- Default networkPolicy that comes out of the box with falcosidekick if you don't have any specific needs.
+defaultNetworkPolicy:
+  enabled: false
+  # The following lines will work only if webui ingress is enabled (webui.ingress.enabled = true)
+  webuiIngressNetworkPolicyNamespaceSelector: {}
+  webuiIngressNetworkPolicyPodSelector: {}
+  # Full Example with nginx (deprecrated) below.
+  # webuiIngressNetworkPolicyNamespaceSelector:
+  #  kubernetes.io/metadata.name: ingress-nginx
+  # webuiIngressNetworkPolicyPodSelector:
+  #  app.kubernetes.io/component: controller
+  #  app.kubernetes.io/instance: ingress-nginx
+  #  app.kubernetes.io/name: ingress-nginx
+
 httproute:
   # -- Whether to create the HTTPRoute (Gateway API). Requires the Gateway API CRDs to be installed in the cluster
   enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"

⚠ Some charts in this repository are **managed**: owned by their source repositories and synced here by Poiana. Direct edits to managed charts will be blocked by the "Guard Managed Charts" check; please open changes against the appropriate source repo. See [.github/managed-charts.yaml](../.github/managed-charts.yaml) for the list of managed charts and their source mapping.
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area falco-chart

/area falcosidekick-chart

> /area falco-talon-chart

> /area event-generator-chart

> /area k8s-metacollector-chart

> /area falco-operator-chart

> /area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

By default no network policy is set by falcosidekick helm chart.
As falco is ran by default as a DaemonSet and requires the securityContext: privileged: true (equivalent to docker --privileged ), it can become a suitable and preferred target for an attacker to get in.

This PR introduce a "default" networkPolicy that can deployed and activated during helm install by setting `defaultNetworkPolicy.enabled: true`.

Extra parameters `defaultNetworkPolicy.webuiIngressNetworkPoliciesNamespaceSelector` and `defaultNetworkPolicy.webuiIngressNetworkPoliciesPodSelector` are configurable to tailor the selectors used to apply an additional and dedicated networkPolicy targeting ingress-controller pods (conditioned by its activation, see `webui.enabled=true` and `webui.ingress.enabled=true`).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #979 

**Special notes for your reviewer**:

Non regression tests Matrix done, and results:
| defaultNetworkPolicy.enabled | webui.enabled  | webui.ingress.enabled | networkPolicy rendered | sidekick-core                                                           | sidekick-ui                                                   | sidekick-ui-redis                                   |
| ---------------------------- | -------------- | --------------------- | ---------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------- |
| false                        | (true / false) | (true / false)        | NO                     | none                                                                    | none                                                          | none                                                |
| true                         | false          | (true / false)        | YES                    | <pre>ingress TCP 2801, TCP 2810</pre><pre>egress UDP 53</pre>           | none                                                          | none                                                |
| true                         | true           | false                 | YES                    | <pre>ingress TCP 2801, TCP 2810</pre><pre>egress UDP 53, TCP 2802</pre> | <pre>ingress TCP 2802*</pre><pre>egress UDP 53, TCP 6379</pre> | <pre>ingress TCP 6379</pre><pre>egress UDP 53</pre> |
| true                         | true           | true                  | YES                    | <pre>ingress TCP 2801, TCP 2810</pre><pre>egress UDP 53, TCP 2802</pre> | <pre>ingress TCP 2802**</pre><pre>egress UDP 53, TCP 6379</pre> | <pre>ingress TCP 6379</pre><pre>egress UDP 53</pre> |

*tcp Port 2802 open only for  sidekick-core
**tcp Port 2802 open for both sidekick-core and ingress

Detailed results in GIST link: https://gist.github.com/heitzflorian/de36a2756471e52bf49569c6f1197241

**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated