### PR TITLE
chore(dependabot): stop security update PRs for managed charts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,13 @@ updates:
       - "charts/falco/**"
       - "charts/falco-operator/**"
       - "charts/k8s-metacollector/**"
+  - package-ecosystem: "gomod"
+    directories:
+      - "/charts/event-generator/**"
+      - "/charts/falco/**"
+      - "/charts/falco-operator/**"
+      - "/charts/k8s-metacollector/**"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) of the main Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"

⚠ Some charts in this repository are **managed**: owned by their source repositories and synced here by Poiana. Direct edits to managed charts will be blocked by the "Guard Managed Charts" check; please open changes against the appropriate source repo. See [.github/managed-charts.yaml](../.github/managed-charts.yaml) for the list of managed charts and their source mapping.
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If this PR will release a new chart version please make sure to also uncomment the following line:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area falco-chart

> /area falcosidekick-chart

> /area falco-talon-chart

> /area event-generator-chart

> /area k8s-metacollector-chart

> /area falco-operator-chart

/area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This adds a dedicated `gomod` update block scoped via `directories` to the four managed-chart paths, with `ignore: dependency-name: "*"`. Unlike `exclude-paths`, the `ignore` option applies to **both** version and security updates, so Dependabot no longer opens any PR (version or security) for the managed charts. The root `gomod` block keeps managing the rest of the repository normally.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


**Checklist**
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] CHANGELOG.md updated
