### PR TITLE
sync(charts/k8s-metacollector): v0.3.1

### DIFF
--- a/charts/k8s-metacollector/CHANGELOG.md
+++ b/charts/k8s-metacollector/CHANGELOG.md
@@ -4,6 +4,12 @@
 This file documents all notable changes to `k8s-metacollector` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## Unreleased
+
+## v0.3.1
+
+* Bump k8s-metacollector to version 0.1.3
+
 ## v0.3.0
 
 * Bump k8s-metacollector to version 0.1.2

--- a/charts/k8s-metacollector/Chart.yaml
+++ b/charts/k8s-metacollector/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.2"
+appVersion: "0.1.3"
 
 home: https://github.com/falcosecurity/k8s-metacollector
 sources:

--- a/charts/k8s-metacollector/README.md
+++ b/charts/k8s-metacollector/README.md
@@ -66,7 +66,7 @@ The command removes all the Kubernetes resources associated with the chart and d
 
 ## Configuration
 
-The following table lists the main configurable parameters of the k8s-metacollector chart v0.3.0 and their default values. See `values.yaml` for full list.
+The following table lists the main configurable parameters of the k8s-metacollector chart v0.3.1 and their default values. See `values.yaml` for full list.
 
 ## Values
 


### PR DESCRIPTION
**What type of PR is this?**

/kind chart-release

**Any specific area of the project related to this PR?**

/area k8s-metacollector-chart

**What this PR does / why we need it**:

Syncs the k8s-metacollector Helm chart from its source repository.

Source chart: https://github.com/falcosecurity/k8s-metacollector/tree/main/chart/k8s-metacollector
Source commit: https://github.com/falcosecurity/k8s-metacollector/commit/e9061768834aa8d5297922fee45ae93de2531102

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Generated by the sync-charts ProwJob. Do not edit this PR directly; change the source chart instead.


**Checklist**
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] CHANGELOG.md updated