### PR TITLE
feat(falco-talon): mount rules ConfigMap as a directory for hot reload

### DIFF
--- a/charts/falco-talon/CHANGELOG.md
+++ b/charts/falco-talon/CHANGELOG.md
@@ -6,6 +6,7 @@ numbering uses [semantic versioning](http://semver.org).
 ## 0.5.0 - 2026-09-07
 
 - mount the rules ConfigMap as a directory (`/etc/falco-talon/rules.d`) instead of a `subPath` file, so ConfigMap updates are propagated by kubelet and picked up by the rules watcher (`watch_rules`) — see falcosecurity/falco-talon#799
+- bump `appVersion` to `0.3.1` (the falco-talon release containing the watcher fix) so the rendered image tag matches the hot-reload behavior
 
 ## 0.4.1 - 2026-06-15
 

--- a/charts/falco-talon/CHANGELOG.md
+++ b/charts/falco-talon/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Falco Talon Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## 0.5.0 - 2026-09-07
+
+- mount the rules ConfigMap as a directory (`/etc/falco-talon/rules.d`) instead of a `subPath` file, so ConfigMap updates are propagated by kubelet and picked up by the rules watcher (`watch_rules`) — see falcosecurity/falco-talon#799
+
 ## 0.4.1 - 2026-06-15
 
 - fix missing namespace in the Secret metadata

--- a/charts/falco-talon/Chart.yaml
+++ b/charts/falco-talon/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.3.0
+appVersion: 0.3.1
 description: React to the events from Falco
 name: falco-talon
 version: 0.5.0

--- a/charts/falco-talon/Chart.yaml
+++ b/charts/falco-talon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.3.0
 description: React to the events from Falco
 name: falco-talon
-version: 0.4.1
+version: 0.5.0
 keywords:
   - falco
   - monitoring

--- a/charts/falco-talon/templates/deployment.yaml
+++ b/charts/falco-talon/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ["server", "-c", "/etc/falco-talon/config.yaml", "-r", "/etc/falco-talon/rules.yaml"]
+          args: ["server", "-c", "/etc/falco-talon/config.yaml", "-r", "/etc/falco-talon/rules.d/rules.yaml"]
           ports:
             - name: http
               containerPort: 2803
@@ -77,8 +77,7 @@ spec:
               subPath: config.yaml
               readOnly: true
             - name: "rules"
-              mountPath: "/etc/falco-talon/rules.yaml"
-              subPath: rules.yaml
+              mountPath: "/etc/falco-talon/rules.d"
               readOnly: true
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
**What this PR does / why we need it:**

kubelet never propagates ConfigMap updates to `subPath`-mounted files, so with the current mount (`mountPath: /etc/falco-talon/rules.yaml` + `subPath: rules.yaml`) **no filesystem event is ever produced** when the rules ConfigMap changes. The `watch_rules` feature can therefore never reload in practice, and users must restart the pods for rule changes to take effect.

This PR mounts the rules ConfigMap as a directory at `/etc/falco-talon/rules.d` and points `-r` at the file inside it. ConfigMap volume updates (symlink swap) then propagate and the watcher reloads rules on the fly, with zero pod restarts.

**Companion to** falcosecurity/falco-talon#799, which fixes the watcher itself to catch the swap events — both are needed for hot reload to work end-to-end.

**Testing performed:**

- `helm lint` passes, `helm template` renders the new args/mount correctly
- on a 3-node kubeadm cluster (chart installed with this change + watcher fix from falco-talon#799): editing the rules ConfigMap → talon logs `changes detected` + `N rules have been successfully loaded` within ~20s, **no pod restarts**; a matching falco event then triggers the freshly loaded rule's action successfully

**Chart version:** bumped to 0.5.0 with CHANGELOG entry.

Signed-off-by: gitlayzer <mr-xintian-du@gmail.com>